### PR TITLE
Refactor the refresher example

### DIFF
--- a/cmd/gettags/main.go
+++ b/cmd/gettags/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"time"
 
 	"github.com/stellentus/go-plc"
 )
@@ -14,9 +13,11 @@ var path = flag.String("path", "1,0", "Path to the PLC at the provided host or I
 func main() {
 	flag.Parse()
 
-	connectionInfo := fmt.Sprintf("protocol=ab_eip&gateway=%s&path=%s&cpu=controllogix", *addr, *path)
-	timeout := 5 * time.Second
-	device, err := plc.NewDevice(connectionInfo, timeout)
+	conf := map[string]string{
+		"gateway": *addr,
+		"path":    *path,
+	}
+	device, err := plc.NewDevice(conf)
 	if err != nil {
 		panic("ERROR " + err.Error() + ": Could not create test PLC!")
 	}

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"time"
 
 	"github.com/stellentus/go-plc"
 )
@@ -16,12 +15,14 @@ var index = flag.Int("index", -1, "Array index to access, or -1 if not an array"
 func main() {
 	flag.Parse()
 
-	connectionInfo := fmt.Sprintf("protocol=ab_eip&gateway=%s&path=%s&cpu=controllogix", *addr, *path)
-	timeout := 5 * time.Second
+	conf := map[string]string{
+		"gateway": *addr,
+		"path":    *path,
+	}
 
-	fmt.Println("Attempting test connection to", connectionInfo, "using", *tagName)
+	fmt.Println("Attempting test connection to", conf["gateway"], "using", *tagName)
 
-	device, err := plc.NewDevice(connectionInfo, timeout)
+	device, err := plc.NewDevice(conf)
 	if err != nil {
 		panic("ERROR " + err.Error() + ": Could not create test PLC!")
 	}

--- a/device_test.go
+++ b/device_test.go
@@ -9,8 +9,28 @@ import (
 )
 
 func TestNewDevice(t *testing.T) {
-	_, err := NewDevice("", 0)
+	_, err := NewDevice(map[string]string{"gateway": "test"})
 	assert.NoError(t, err)
+}
+
+func TestNewDeviceRequiresConfig(t *testing.T) {
+	_, err := NewDevice(nil)
+	assert.Error(t, err)
+}
+
+func TestNewDeviceRequiresGateway(t *testing.T) {
+	_, err := NewDevice(map[string]string{})
+	assert.Error(t, err)
+}
+
+func TestNewDeviceParsesTimeout(t *testing.T) {
+	_, err := NewDevice(map[string]string{"gateway": "test", "timeout": "250ms"})
+	assert.NoError(t, err)
+}
+
+func TestNewDeviceInvalidTimeout(t *testing.T) {
+	_, err := NewDevice(map[string]string{"gateway": "test", "timeout": "fifty milliseconds"})
+	assert.Error(t, err)
 }
 
 func newTestDevice(rd rawDevice) *Device {

--- a/example/refresher/main.go
+++ b/example/refresher/main.go
@@ -40,7 +40,7 @@ func newPlant() (refresher plc.Reader, plant plc.ReadWriter) {
 	fmt.Printf("Creating a pool of %d threads\n", *numWorkers)
 	pooled := plc.NewPooled(device, *numWorkers)
 
-	debug := ReaderFunc(func(name string, value interface{}) error {
+	debug := plc.ReaderFunc(func(name string, value interface{}) error {
 		fmt.Printf("Read: %s is %v\n", name, reflect.ValueOf(value).Elem())
 		return pooled.ReadTag(name, value)
 	})
@@ -49,13 +49,4 @@ func newPlant() (refresher plc.Reader, plant plc.ReadWriter) {
 	refresher = plc.NewRefresher(debug, *refreshDuration)
 
 	return refresher, pooled
-}
-
-// ReaderFunc is a function that can be used as a Reader.
-// It's the same pattern as http.HandlerFunc.
-// Maybe this should eventually be moved into the package if it seems useful.
-type ReaderFunc func(name string, value interface{}) error
-
-func (rt ReaderFunc) ReadTag(name string, value interface{}) error {
-	return rt(name, value)
 }

--- a/example/refresher/main.go
+++ b/example/refresher/main.go
@@ -10,8 +10,6 @@ import (
 )
 
 var addr = flag.String("address", "192.168.1.176", "Hostname or IP address of the PLC")
-var path = flag.String("path", "1,0", "Path to the PLC at the provided host or IP")
-var timeout = flag.Duration("timeout", 5*time.Second, "PLC communication timeout")
 var numWorkers = flag.Int("workers", 1, "Number of worker threads talking to libplctag")
 var refreshDuration = flag.Duration("refresh", time.Second, "Refresh period")
 var tagName = flag.String("tagName", "DUMMY_AQUA_DATA_0[0]", "Name of the uint8 tag to read repeatedly")
@@ -20,10 +18,11 @@ var tagName = flag.String("tagName", "DUMMY_AQUA_DATA_0[0]", "Name of the uint8 
 func main() {
 	flag.Parse()
 
-	dev, err := example.NewDevice(*addr, *path, *timeout, example.Config{
-		Workers:        *numWorkers,
-		PrintReadDebug: true,
-		DebugFunc:      fmt.Printf,
+	dev, err := example.NewDevice(example.Config{
+		Workers:          *numWorkers,
+		PrintReadDebug:   true,
+		DebugFunc:        fmt.Printf,
+		DeviceConnection: map[string]string{"gateway": *addr},
 	})
 	if err != nil {
 		panic("ERROR " + err.Error() + ": Could not create test PLC!")

--- a/example/refresher/main.go
+++ b/example/refresher/main.go
@@ -20,11 +20,14 @@ var tagName = flag.String("tagName", "DUMMY_AQUA_DATA_0[0]", "Name of the uint8 
 func main() {
 	flag.Parse()
 
-	dev := example.NewDevice(*addr, *path, *timeout, example.Config{
+	dev, err := example.NewDevice(*addr, *path, *timeout, example.Config{
 		Workers:        *numWorkers,
 		PrintReadDebug: true,
 		DebugFunc:      fmt.Printf,
 	})
+	if err != nil {
+		panic("ERROR " + err.Error() + ": Could not create test PLC!")
+	}
 
 	fmt.Printf("Creating a refresher to reload every %v\n", *refreshDuration)
 	refresher := plc.NewRefresher(dev, *refreshDuration)

--- a/example/refresher/main.go
+++ b/example/refresher/main.go
@@ -20,7 +20,9 @@ var tagName = flag.String("tagName", "DUMMY_AQUA_DATA_0[0]", "Name of the uint8 
 func main() {
 	flag.Parse()
 
-	dev := example.NewDebugPooledDevice(*addr, *path, *timeout, *numWorkers)
+	dev := example.NewDebugPooledDevice(*addr, *path, *timeout, example.Config{
+		Workers: *numWorkers,
+	})
 
 	fmt.Printf("Creating a refresher to reload every %v\n", *refreshDuration)
 	refresher := plc.NewRefresher(dev, *refreshDuration)

--- a/example/refresher/main.go
+++ b/example/refresher/main.go
@@ -20,7 +20,7 @@ var tagName = flag.String("tagName", "DUMMY_AQUA_DATA_0[0]", "Name of the uint8 
 func main() {
 	flag.Parse()
 
-	dev := example.NewCompositeDevice(*addr, *path, *timeout, example.Config{
+	dev := example.NewDevice(*addr, *path, *timeout, example.Config{
 		Workers:        *numWorkers,
 		PrintReadDebug: true,
 		DebugFunc:      fmt.Printf,

--- a/example/refresher/main.go
+++ b/example/refresher/main.go
@@ -28,6 +28,12 @@ func main() {
 	if err != nil {
 		panic("ERROR " + err.Error() + ": Could not create test PLC!")
 	}
+	defer func() {
+		err := dev.Close()
+		if err != nil {
+			panic("ERROR: Close was unsuccessful:" + err.Error())
+		}
+	}()
 
 	fmt.Printf("Creating a refresher to reload every %v\n", *refreshDuration)
 	refresher := plc.NewRefresher(dev, *refreshDuration)

--- a/example/refresher/main.go
+++ b/example/refresher/main.go
@@ -23,6 +23,7 @@ func main() {
 	dev := example.NewCompositeDevice(*addr, *path, *timeout, example.Config{
 		Workers:        *numWorkers,
 		PrintReadDebug: true,
+		DebugFunc:      fmt.Printf,
 	})
 
 	fmt.Printf("Creating a refresher to reload every %v\n", *refreshDuration)

--- a/example/refresher/main.go
+++ b/example/refresher/main.go
@@ -21,7 +21,8 @@ func main() {
 	flag.Parse()
 
 	dev := example.NewDebugPooledDevice(*addr, *path, *timeout, example.Config{
-		Workers: *numWorkers,
+		Workers:        *numWorkers,
+		PrintReadDebug: true,
 	})
 
 	fmt.Printf("Creating a refresher to reload every %v\n", *refreshDuration)

--- a/example/refresher/main.go
+++ b/example/refresher/main.go
@@ -20,7 +20,7 @@ var tagName = flag.String("tagName", "DUMMY_AQUA_DATA_0[0]", "Name of the uint8 
 func main() {
 	flag.Parse()
 
-	dev := example.NewDebugPooledDevice(*addr, *path, *timeout, example.Config{
+	dev := example.NewCompositeDevice(*addr, *path, *timeout, example.Config{
 		Workers:        *numWorkers,
 		PrintReadDebug: true,
 	})

--- a/example/refresher/main.go
+++ b/example/refresher/main.go
@@ -3,16 +3,16 @@ package main
 import (
 	"flag"
 	"fmt"
-	"reflect"
 	"time"
 
 	"github.com/stellentus/go-plc"
+	"github.com/stellentus/go-plc/example"
 )
 
 var addr = flag.String("address", "192.168.1.176", "Hostname or IP address of the PLC")
 var path = flag.String("path", "1,0", "Path to the PLC at the provided host or IP")
-var numWorkers = flag.Int("workers", 1, "Number of worker threads talking to libplctag")
 var timeout = flag.Duration("timeout", 5*time.Second, "PLC communication timeout")
+var numWorkers = flag.Int("workers", 1, "Number of worker threads talking to libplctag")
 var refreshDuration = flag.Duration("refresh", time.Second, "Refresh period")
 var tagName = flag.String("tagName", "DUMMY_AQUA_DATA_0[0]", "Name of the uint8 tag to read repeatedly")
 
@@ -20,33 +20,12 @@ var tagName = flag.String("tagName", "DUMMY_AQUA_DATA_0[0]", "Name of the uint8 
 func main() {
 	flag.Parse()
 
-	refresher, _ := newPlant()
+	dev := example.NewDebugPooledDevice(*addr, *path, *timeout, *numWorkers)
+
+	fmt.Printf("Creating a refresher to reload every %v\n", *refreshDuration)
+	refresher := plc.NewRefresher(dev, *refreshDuration)
 
 	val := uint8(0)
 	refresher.ReadTag(*tagName, &val)
 	time.Sleep(10 * time.Second)
-}
-
-func newPlant() (refresher plc.Reader, plant plc.ReadWriter) {
-	connectionInfo := fmt.Sprintf("protocol=ab_eip&gateway=%s&path=%s&cpu=controllogix", *addr, *path)
-
-	fmt.Println("Initializing connection to", connectionInfo)
-	device, err := plc.NewDevice(connectionInfo, *timeout)
-	if err != nil {
-		panic("ERROR " + err.Error() + ": Could not create test PLC!")
-	}
-	// WARNING device.Close() should be called
-
-	fmt.Printf("Creating a pool of %d threads\n", *numWorkers)
-	pooled := plc.NewPooled(device, *numWorkers)
-
-	debug := plc.ReaderFunc(func(name string, value interface{}) error {
-		fmt.Printf("Read: %s is %v\n", name, reflect.ValueOf(value).Elem())
-		return pooled.ReadTag(name, value)
-	})
-
-	fmt.Printf("Creating a refresher to reload every %v\n", *refreshDuration)
-	refresher = plc.NewRefresher(debug, *refreshDuration)
-
-	return refresher, pooled
 }

--- a/example/setup.go
+++ b/example/setup.go
@@ -23,7 +23,7 @@ type Config struct {
 	DebugFunc func(string, ...interface{}) (int, error)
 }
 
-func NewCompositeDevice(addr string, path string, timeout time.Duration, conf Config) plc.ReadWriteCloser {
+func NewDevice(addr string, path string, timeout time.Duration, conf Config) plc.ReadWriteCloser {
 	connectionInfo := fmt.Sprintf("protocol=ab_eip&gateway=%s&path=%s&cpu=controllogix", addr, path)
 
 	if conf.DebugFunc == nil {

--- a/example/setup.go
+++ b/example/setup.go
@@ -1,9 +1,7 @@
 package example
 
 import (
-	"fmt"
 	"reflect"
-	"time"
 
 	"github.com/stellentus/go-plc"
 )
@@ -23,11 +21,12 @@ type Config struct {
 	// DebugFunc prints debug.
 	// If nil, nothing is printed.
 	DebugFunc
+
+	// DeviceConnection is the map used by plc.Device to initialize the connection.
+	DeviceConnection map[string]string
 }
 
-func NewDevice(addr string, path string, timeout time.Duration, conf Config) (plc.ReadWriteCloser, error) {
-	connectionInfo := fmt.Sprintf("protocol=ab_eip&gateway=%s&path=%s&cpu=controllogix", addr, path)
-
+func NewDevice(conf Config) (plc.ReadWriteCloser, error) {
 	if conf.DebugFunc == nil {
 		conf.DebugFunc = doNothing
 	}
@@ -35,8 +34,8 @@ func NewDevice(addr string, path string, timeout time.Duration, conf Config) (pl
 	var rwc plc.ReadWriteCloser
 	var err error
 
-	conf.DebugFunc("Initializing connection to %s\n", connectionInfo)
-	rwc, err = plc.NewDevice(connectionInfo, timeout)
+	conf.DebugFunc("Initializing connection to %s\n", conf.DeviceConnection["gateway"])
+	rwc, err = plc.NewDevice(conf.DeviceConnection)
 	if err != nil {
 		return nil, err
 	}

--- a/example/setup.go
+++ b/example/setup.go
@@ -9,8 +9,13 @@ import (
 )
 
 type Config struct {
-	Workers         int
-	PrintReadDebug  bool
+	// Workers creates a pool of workers if greater than 0.
+	Workers int
+
+	// PrintReadDebug creates a wrapper to print the value being read.
+	PrintReadDebug bool
+
+	// PrintWriteDebug creates a wrapper to print the value being written.
 	PrintWriteDebug bool
 }
 

--- a/example/setup.go
+++ b/example/setup.go
@@ -13,7 +13,7 @@ type Config struct {
 	PrintReadDebug bool
 }
 
-func NewDebugPooledDevice(addr string, path string, timeout time.Duration, conf Config) plc.ReadWriteCloser {
+func NewCompositeDevice(addr string, path string, timeout time.Duration, conf Config) plc.ReadWriteCloser {
 	connectionInfo := fmt.Sprintf("protocol=ab_eip&gateway=%s&path=%s&cpu=controllogix", addr, path)
 
 	fmt.Println("Initializing connection to", connectionInfo)

--- a/example/setup.go
+++ b/example/setup.go
@@ -1,0 +1,43 @@
+package example
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/stellentus/go-plc"
+)
+
+func NewDebugPooledDevice(addr string, path string, timeout time.Duration, numWorkers int) plc.ReadWriteCloser {
+	connectionInfo := fmt.Sprintf("protocol=ab_eip&gateway=%s&path=%s&cpu=controllogix", addr, path)
+
+	fmt.Println("Initializing connection to", connectionInfo)
+	device, err := plc.NewDevice(connectionInfo, timeout)
+	if err != nil {
+		panic("ERROR " + err.Error() + ": Could not create test PLC!")
+	}
+	defer func() {
+		err := device.Close()
+		if err != nil {
+			fmt.Println("Close was unsuccessful:", err.Error())
+		}
+	}()
+
+	fmt.Printf("Creating a pool of %d threads\n", numWorkers)
+	pooled := plc.NewPooled(device, numWorkers)
+
+	debug := plc.ReaderFunc(func(name string, value interface{}) error {
+		fmt.Printf("Read: %s is %v\n", name, reflect.ValueOf(value).Elem())
+		return pooled.ReadTag(name, value)
+	})
+
+	return struct {
+		plc.Reader
+		plc.Writer
+		plc.Closer
+	}{
+		Reader: debug,
+		Writer: pooled,
+		Closer: device,
+	}
+}

--- a/example/setup.go
+++ b/example/setup.go
@@ -9,7 +9,8 @@ import (
 )
 
 type Config struct {
-	Workers int
+	Workers        int
+	PrintReadDebug bool
 }
 
 func NewDebugPooledDevice(addr string, path string, timeout time.Duration, conf Config) plc.ReadWriteCloser {
@@ -29,10 +30,14 @@ func NewDebugPooledDevice(addr string, path string, timeout time.Duration, conf 
 
 	rwc := plc.ReadWriteCloser(device)
 
-	fmt.Printf("Creating a pool of %d threads\n", conf.Workers)
-	rwc = plc.NewPooled(rwc, conf.Workers).WithCloser(rwc)
+	if conf.Workers > 0 {
+		fmt.Printf("Creating a pool of %d threads\n", conf.Workers)
+		rwc = plc.NewPooled(rwc, conf.Workers).WithCloser(rwc)
+	}
 
-	rwc = PrintReadDebug(rwc)
+	if conf.PrintReadDebug {
+		rwc = PrintReadDebug(rwc)
+	}
 
 	return rwc
 }

--- a/example/setup.go
+++ b/example/setup.go
@@ -35,12 +35,6 @@ func NewDevice(addr string, path string, timeout time.Duration, conf Config) (pl
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		err := device.Close()
-		if err != nil {
-			fmt.Println("Close was unsuccessful:", err.Error())
-		}
-	}()
 
 	rwc := plc.ReadWriteCloser(device)
 

--- a/example/setup.go
+++ b/example/setup.go
@@ -58,16 +58,26 @@ func NewDevice(addr string, path string, timeout time.Duration, conf Config) (pl
 func PrintReadDebug(rwc plc.ReadWriteCloser) plc.ReadWriteCloser {
 	read := rwc.ReadTag
 	return plc.ReaderFunc(func(name string, value interface{}) error {
-		fmt.Printf("Read: %s is %v\n", name, reflect.ValueOf(value).Elem())
-		return read(name, value)
+		err := read(name, value)
+		if err != nil {
+			fmt.Printf("Read FAILURE for %s (%v)\n", name, err)
+		} else {
+			fmt.Printf("Read: %s is %v\n", name, reflect.ValueOf(value).Elem())
+		}
+		return err
 	}).WithWriteCloser(rwc)
 }
 
 func PrintWriteDebug(rwc plc.ReadWriteCloser) plc.ReadWriteCloser {
 	write := rwc.WriteTag
 	return plc.WriterFunc(func(name string, value interface{}) error {
-		fmt.Printf("Write: %s is %v\n", name, reflect.ValueOf(value))
-		return write(name, value)
+		err := write(name, value)
+		if err != nil {
+			fmt.Printf("Write FAILURE setting %s to %v (%v)\n", name, reflect.ValueOf(value), err)
+		} else {
+			fmt.Printf("Write: %s is %v\n", name, reflect.ValueOf(value))
+		}
+		return err
 	}).WithReadCloser(rwc)
 }
 

--- a/example/setup.go
+++ b/example/setup.go
@@ -23,7 +23,7 @@ type Config struct {
 	DebugFunc func(string, ...interface{}) (int, error)
 }
 
-func NewDevice(addr string, path string, timeout time.Duration, conf Config) plc.ReadWriteCloser {
+func NewDevice(addr string, path string, timeout time.Duration, conf Config) (plc.ReadWriteCloser, error) {
 	connectionInfo := fmt.Sprintf("protocol=ab_eip&gateway=%s&path=%s&cpu=controllogix", addr, path)
 
 	if conf.DebugFunc == nil {
@@ -33,7 +33,7 @@ func NewDevice(addr string, path string, timeout time.Duration, conf Config) plc
 	conf.DebugFunc("Initializing connection to %s\n", connectionInfo)
 	device, err := plc.NewDevice(connectionInfo, timeout)
 	if err != nil {
-		panic("ERROR " + err.Error() + ": Could not create test PLC!")
+		return nil, err
 	}
 	defer func() {
 		err := device.Close()
@@ -57,7 +57,7 @@ func NewDevice(addr string, path string, timeout time.Duration, conf Config) plc
 		rwc = PrintWriteDebug(rwc)
 	}
 
-	return rwc
+	return rwc, nil
 }
 
 func PrintReadDebug(rwc plc.ReadWriteCloser) plc.ReadWriteCloser {

--- a/example/setup.go
+++ b/example/setup.go
@@ -30,13 +30,14 @@ func NewDevice(addr string, path string, timeout time.Duration, conf Config) (pl
 		conf.DebugFunc = doNothing
 	}
 
+	var rwc plc.ReadWriteCloser
+	var err error
+
 	conf.DebugFunc("Initializing connection to %s\n", connectionInfo)
-	device, err := plc.NewDevice(connectionInfo, timeout)
+	rwc, err = plc.NewDevice(connectionInfo, timeout)
 	if err != nil {
 		return nil, err
 	}
-
-	rwc := plc.ReadWriteCloser(device)
 
 	if conf.Workers > 0 {
 		conf.DebugFunc("Creating a pool of %d threads\n", conf.Workers)

--- a/example/setup.go
+++ b/example/setup.go
@@ -8,7 +8,11 @@ import (
 	"github.com/stellentus/go-plc"
 )
 
-func NewDebugPooledDevice(addr string, path string, timeout time.Duration, numWorkers int) plc.ReadWriteCloser {
+type Config struct {
+	Workers int
+}
+
+func NewDebugPooledDevice(addr string, path string, timeout time.Duration, conf Config) plc.ReadWriteCloser {
 	connectionInfo := fmt.Sprintf("protocol=ab_eip&gateway=%s&path=%s&cpu=controllogix", addr, path)
 
 	fmt.Println("Initializing connection to", connectionInfo)
@@ -23,8 +27,8 @@ func NewDebugPooledDevice(addr string, path string, timeout time.Duration, numWo
 		}
 	}()
 
-	fmt.Printf("Creating a pool of %d threads\n", numWorkers)
-	pooled := plc.NewPooled(device, numWorkers)
+	fmt.Printf("Creating a pool of %d threads\n", conf.Workers)
+	pooled := plc.NewPooled(device, conf.Workers)
 
 	debug := plc.ReaderFunc(func(name string, value interface{}) error {
 		fmt.Printf("Read: %s is %v\n", name, reflect.ValueOf(value).Elem())

--- a/interfaces.go
+++ b/interfaces.go
@@ -5,6 +5,14 @@ type ReadWriter interface {
 	Writer
 }
 
+type ReadWriteCloser interface {
+	Reader
+	Writer
+
+	// Close cleans up resources.
+	Close() error
+}
+
 // Reader writes values from a PLC.
 type Reader interface {
 	// ReadTag reads the requested tag into the provided value.
@@ -19,10 +27,7 @@ type Writer interface {
 
 // rawDevice is an interface to a PLC device.
 type rawDevice interface {
-	ReadWriter
-
-	// Close cleans up resources.
-	Close() error
+	ReadWriteCloser
 
 	// GetList gets a list of tag names for the provided program
 	// name (or all tags if no program name is provided).

--- a/interfaces.go
+++ b/interfaces.go
@@ -11,21 +11,23 @@ type ReadWriteCloser interface {
 	Closer
 }
 
-// Reader writes values from a PLC.
+// Reader is the interface that wraps the basic ReadTag method.
 type Reader interface {
 	// ReadTag reads the requested tag into the provided value.
 	ReadTag(name string, value interface{}) error
 }
 
-// Writer writes values out to a PLC.
+// Writer is the interface that wraps the basic WriteTag method.
 type Writer interface {
 	// WriteTag writes the provided tag and value.
 	WriteTag(name string, value interface{}) error
 }
 
-// Closer closes something.
+// Closer is the interface that wraps the basic Close method.
+//
+// The behavior of Close after the first call is undefined.
+// Specific implementations may document their own behavior.
 type Closer interface {
-	// Close cleans up resources.
 	Close() error
 }
 

--- a/interfaces.go
+++ b/interfaces.go
@@ -8,9 +8,7 @@ type ReadWriter interface {
 type ReadWriteCloser interface {
 	Reader
 	Writer
-
-	// Close cleans up resources.
-	Close() error
+	Closer
 }
 
 // Reader writes values from a PLC.
@@ -23,6 +21,12 @@ type Reader interface {
 type Writer interface {
 	// WriteTag writes the provided tag and value.
 	WriteTag(name string, value interface{}) error
+}
+
+// Closer closes something.
+type Closer interface {
+	// Close cleans up resources.
+	Close() error
 }
 
 // rawDevice is an interface to a PLC device.

--- a/interfaces.go
+++ b/interfaces.go
@@ -32,3 +32,19 @@ type rawDevice interface {
 	// name (or all tags if no program name is provided).
 	GetList(listName, prefix string) ([]Tag, []string, error)
 }
+
+// ReaderFunc is a function that can be used as a Reader.
+// It's the same pattern as http.HandlerFunc.
+type ReaderFunc func(name string, value interface{}) error
+
+func (f ReaderFunc) ReadTag(name string, value interface{}) error {
+	return f(name, value)
+}
+
+// WriterFunc is a function that can be used as a Writer.
+// It's the same pattern as http.HandlerFunc.
+type WriterFunc func(name string, value interface{}) error
+
+func (f WriterFunc) WriteTag(name string, value interface{}) error {
+	return f(name, value)
+}

--- a/interfaces.go
+++ b/interfaces.go
@@ -19,11 +19,7 @@ type Writer interface {
 
 // rawDevice is an interface to a PLC device.
 type rawDevice interface {
-	// ReadTag reads the requested tag into the provided value.
-	ReadTag(name string, value interface{}) error
-
-	// WriteTag writes the provided tag and value.
-	WriteTag(name string, value interface{}) error
+	ReadWriter
 
 	// Close cleans up resources.
 	Close() error

--- a/interfaces.go
+++ b/interfaces.go
@@ -5,6 +5,16 @@ type ReadWriter interface {
 	Writer
 }
 
+type ReadCloser interface {
+	Reader
+	Closer
+}
+
+type WriteCloser interface {
+	Writer
+	Closer
+}
+
 type ReadWriteCloser interface {
 	Reader
 	Writer
@@ -48,10 +58,28 @@ func (f ReaderFunc) ReadTag(name string, value interface{}) error {
 	return f(name, value)
 }
 
+// WithWriteCloser creates a ReadWriteCloser from ReaderFunc and the provided WriteCloser.
+func (f ReaderFunc) WithWriteCloser(wc WriteCloser) ReadWriteCloser {
+	return struct {
+		Reader
+		Writer
+		Closer
+	}{Reader: f, Writer: wc, Closer: wc}
+}
+
 // WriterFunc is a function that can be used as a Writer.
 // It's the same pattern as http.HandlerFunc.
 type WriterFunc func(name string, value interface{}) error
 
 func (f WriterFunc) WriteTag(name string, value interface{}) error {
 	return f(name, value)
+}
+
+// WithReadCloser creates a ReadWriteCloser from WriterFunc and the provided ReadCloser.
+func (f WriterFunc) WithReadCloser(rc ReadCloser) ReadWriteCloser {
+	return struct {
+		Reader
+		Writer
+		Closer
+	}{Reader: rc, Writer: f, Closer: rc}
 }

--- a/pooled.go
+++ b/pooled.go
@@ -26,6 +26,17 @@ func (p Pooled) WriteTag(name string, value interface{}) error {
 	return p.write.task(func() error { return p.plc.WriteTag(name, value) })
 }
 
+// WithCloser creates a ReadWriteCloser from Pooled and the provided Closer.
+func (p Pooled) WithCloser(cl Closer) ReadWriteCloser {
+	return struct {
+		ReadWriter
+		Closer
+	}{
+		ReadWriter: p,
+		Closer:     cl,
+	}
+}
+
 type task func()
 type tasker chan task
 

--- a/refresher.go
+++ b/refresher.go
@@ -55,3 +55,16 @@ func (r *Refresher) ReadTag(name string, value interface{}) error {
 
 	return r.plc.ReadTag(name, value)
 }
+
+// WithWriteCloser creates a ReadWriteCloser from Refresher and the provided WriteCloser.
+func (r *Refresher) WithWriteCloser(wc WriteCloser) ReadWriteCloser {
+	return struct {
+		Reader
+		Writer
+		Closer
+	}{
+		Reader: r,
+		Writer: wc,
+		Closer: wc,
+	}
+}


### PR DESCRIPTION
This does a few things:
1. Change `NewDevice` to take a `map[string]string` instead of a pre-constructed string. This allows defaults for everything except the network address.
2. Add new interfaces (e.g. `WriteCloser`)
3. Add wrappers to conveniently transform subsets of `ReadWriteCloser` into a `ReadWriteCloser`.
4. Add function wrappers styled after `http.HandlerFunc`
5. Create a factory in `example/setup`. This is to make it easy to construct a chain of interfaces in the way we've designed them to be created. This way all of the examples, test commands, and production commands can use the same factory. Overkill?

Questions:
* Which of these things do you hate?
* If point 5 is ok, should it move to a package (e.g. `factory.NewDevice`) and be used in all of `cmd`?
* I think `interfaces.go` belongs as two different files, but I wasn't sure how to name the other one. `funcwrapper.go` is two words.