### PR TITLE
Provide a way to get errors from Refresher

### DIFF
--- a/refresher.go
+++ b/refresher.go
@@ -5,7 +5,7 @@ package plc
 */
 import "C"
 import (
-	"fmt"
+	"log"
 	"reflect"
 	"sync"
 	"time"
@@ -61,7 +61,7 @@ func (r *Refresher) ReadTag(name string, value interface{}) error {
 			if r.ErrorCallback != nil {
 				r.ErrorCallback(err)
 			} else {
-				fmt.Println("WARNING: Unhandled plc.Refresher.ReadTag error:", err)
+				log.Println("WARNING: Unhandled plc.Refresher.ReadTag error:", err)
 			}
 		}
 	})


### PR DESCRIPTION
Were you planning to write test code for `Refresher`? If so, then I can add a test for this at that point. But I've tested it with `example/refresher` and it works.