### PR TITLE
Parser for fully qualified tag names

### DIFF
--- a/tag.go
+++ b/tag.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"unicode"
 )
 
 const SystemTagBit = 0x1000
@@ -53,4 +54,67 @@ func (tag Tag) ElemCount() int {
 		}
 	}
 	return count
+}
+
+// ParseQualifiedTagName consumes a tag name containing
+// zero or more qualifications (ie. a field name or an
+// array index) and splits them into their respresentative
+// parts.
+//
+// Grammar: QualifiedTagName -> TagName (TagSeparator TagName)*
+//          TagSeparator     -> ArrayIndex+ | FieldSeparator
+//          TagName          -> (PRINTABLE_ASCII_CHARACTER)+
+//          ArrayIndex       -> "[" NUMBER "]"
+//          FieldSeparator   -> "."
+func ParseQualifiedTagName(qtn string) ([]string, error) {
+	var ret []string
+
+	if qtn == "" {
+		return nil, fmt.Errorf("Empty tagname supplied")
+	}
+	for i, c := range qtn {
+		if unicode.IsSpace(c) {
+			return nil, fmt.Errorf("Whitespace character at index %d", i)
+		}
+		if c < 32 || c > unicode.MaxASCII {
+			return nil, fmt.Errorf("Non-ASCII character (codepoint %d) at index %d", int(c), i)
+		}
+	}
+
+	fields := strings.Split(qtn, ".")
+	for i, f := range fields {
+		if f == "" {
+			return nil, fmt.Errorf("Field #%d: Empty tagname supplied", i+1)
+		}
+		openBracketIdx := strings.Index(f, "[")
+		if openBracketIdx == -1 {
+			// No '['; ensure the rest of the field has no unmatched ']'
+			if strings.Index(f, "]") == -1 {
+				ret = append(ret, f)
+			} else {
+				return nil, fmt.Errorf("Field #%d: ']' without '['", i+1)
+			}
+		} else if openBracketIdx == 0 {
+			// The field begins with an open bracket; we're missing the field name
+			return nil, fmt.Errorf("Field #%d: '[' without array identifier", i+1)
+		} else {
+			arrayName := f[:openBracketIdx]
+			ret = append(ret, arrayName)
+			arrayIndices := strings.Split(f[openBracketIdx+1:], "[")
+			for _, a := range arrayIndices {
+				// We've gotten as far as "FieldName["; do we have a matching ']'
+				// and a valid unsigned int for the index?
+				closing := strings.Index(a, "]")
+				if closing == -1 {
+					return nil, fmt.Errorf("Field #%d: '[' without ']'", i+1)
+				}
+				idx := a[:closing]
+				if _, err := strconv.ParseUint(idx, 10, 32); err != nil {
+					return nil, fmt.Errorf("Field #%d: Invalid array index: %v", i+1, err)
+				}
+				ret = append(ret, idx)
+			}
+		}
+	}
+	return ret, nil
 }

--- a/tag_test.go
+++ b/tag_test.go
@@ -1,0 +1,65 @@
+package plc
+
+import (
+	"strings"
+	"testing"
+)
+
+var parserTests = []struct {
+	in     string
+	out    []string
+	errMsg string
+}{
+	{"", nil, "Empty tagname"},
+	{" ", nil, "Whitespace"},
+	{"\t", nil, "Whitespace"},
+	{"\n", nil, "Whitespace"},
+	{"\b", nil, "Non-ASCII"},
+	{"标志名称", nil, "Non-ASCII"},
+	{"DUMMY_AQUA_TEST_0", []string{"DUMMY_AQUA_TEST_0"}, ""},
+	{"DUMMY_AQUA_TEST_0.DUMMY_AQUA_TEST_1", []string{"DUMMY_AQUA_TEST_0", "DUMMY_AQUA_TEST_1"}, ""},
+	{"DUMMY_AQUA_TEST_0..DUMMY_AQUA_TEST_1", nil, "Empty"},
+	{"[0]", nil, "'[' without array identifier"},
+	{"ARRAY[0]", []string{"ARRAY", "0"}, ""},
+	{"ARRAY[foo]", nil, "Invalid array index"},
+	{"ARRAY[-1]", nil, "Invalid array index"},
+	{"ARRAY[0", nil, "'[' without ']'"},
+	{"ARRAY[[0", nil, "'[' without ']'"},
+	{"ARRAY[0][", nil, "'[' without ']'"},
+	{"ARRAY0]", nil, "']' without '['"},
+	{"DUMMY_AQUA_TEST.[0]", nil, "'[' without array identifier"},
+	{"ARRAY[0][1][2]", []string{"ARRAY", "0", "1", "2"}, ""},
+	{"Field.Array[42].Member[16]", []string{"Field", "Array", "42", "Member", "16"}, ""},
+}
+
+func compareStrSlices(s1, s2 []string) bool {
+	if len(s1) != len(s2) {
+		return false
+	}
+	for i := 0; i < len(s1); i++ {
+		if s1[i] != s2[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestParser(t *testing.T) {
+	for _, test := range parserTests {
+		out, err := ParseQualifiedTagName(test.in)
+		if !compareStrSlices(out, test.out) {
+			t.Errorf("ParseQualifiedTagName(\"%v\"): Return value: Got %v, expected %v", test.in, out, test.out)
+		}
+		if err == nil && test.errMsg != "" {
+			t.Errorf("ParseQualifiedTagName(\"%v\"): Error value: Got nil error, expected error containing %v", test.in, test.errMsg)
+		}
+		if err != nil && test.errMsg == "" {
+			t.Errorf("ParseQualifiedTagName(\"%v\"): Return value: Got non-nil error %v, expected nil error", test.in, err)
+		}
+		if err != nil {
+			if !strings.Contains(err.Error(), test.errMsg) {
+				t.Errorf("ParseQualifiedTagName(\"%v\"): Error value: Got \"%v\", should contain \"%v\"", test.in, err.Error(), test.errMsg)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Implements a function that parses a string containing a fully-qualified
tag name (ie. a sequence of tag names and '.' field separators or array
indexes) into their constituent parts.

Part of WTP-19: each constituent string returned by the parser will be used to
identify a node in the tag locktree.

Splitting this into its own patch because we may want this to live farther
up the stack towards the API, since presumably we'll need something like
this for the typechecking functionality.  If that's the case, the return type
perhaps shouldn't be a slice of strings but perhaps some other tagtype-aware
datatype.