### PR TITLE
Improve compiler check

### DIFF
--- a/device.go
+++ b/device.go
@@ -47,13 +47,8 @@ func NewDevice(addr string, opts ...DeviceOptionFunc) (*Device, error) {
 		conConf += "&" + name + "=" + val
 	}
 
-	raw, err := newLibplctagDevice(conConf, dev.timeout)
-	if err != nil {
-		return nil, err
-	}
-
+	dev.rawDevice = newLibplctagDevice(conConf, dev.timeout)
 	dev.isConnected = true
-	dev.rawDevice = &raw
 	return dev, nil
 }
 

--- a/device_test.go
+++ b/device_test.go
@@ -78,8 +78,8 @@ func TestWriteTag(t *testing.T) {
 	assert.Equal(t, 9, fake.DeviceFake[testTagName])
 }
 
-var _ = ReadWriter(&RawDeviceFake{}) // Compiler makes sure this type is a ReadWriter
-var _ = rawDevice(&RawDeviceFake{})  // Compiler makes sure this type is a rawDevice
+var _ = ReadWriter(RawDeviceFake{}) // Compiler makes sure this type is a ReadWriter
+var _ = rawDevice(RawDeviceFake{})  // Compiler makes sure this type is a rawDevice
 
 // RawDeviceFake adds lower APIs to a DeviceFake
 type RawDeviceFake struct {

--- a/libplctagdevice.go
+++ b/libplctagdevice.go
@@ -42,14 +42,12 @@ var _ = ReadWriter(&libplctagDevice{}) // Compiler makes sure this type is a Rea
 // newLibplctagDevice creates a new libplctagDevice.
 // The conConf string provides IP and other connection configuration (see libplctag for options).
 // It is not thread safe.
-func newLibplctagDevice(conConf string, timeout time.Duration) (libplctagDevice, error) {
-	dev := libplctagDevice{
+func newLibplctagDevice(conConf string, timeout time.Duration) *libplctagDevice {
+	return &libplctagDevice{
 		conConf: conConf,
 		ids:     make(map[string]C.int32_t),
 		timeout: C.int(timeout.Milliseconds()),
 	}
-
-	return dev, nil
 }
 
 // Close should be called on the libplctagDevice to clean up its resources.

--- a/pooled.go
+++ b/pooled.go
@@ -6,7 +6,7 @@ type Pooled struct {
 	read, write tasker
 }
 
-var _ = ReadWriter(&Pooled{}) // Compiler makes sure this type is a ReadWriter
+var _ = ReadWriter(Pooled{}) // Compiler makes sure this type is a ReadWriter
 
 // NewPooled creates a new Pooled and launches worker goroutines to handle incoming reads and writes.
 // There is no way to kill the workers once they're launched.


### PR DESCRIPTION
* Since `Pooled{}` implements the interface, that's what we should be checking. (The check still passed, but this is more strict.)