### PR TITLE
TagLocker ReadWriter impl

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/stellentus/go-plc
 
 go 1.14
 
-require github.com/stretchr/testify v1.6.1
+require (
+	github.com/dijkstracula/go-ilock v0.0.0-20210108024717-0c2939783db9
+	github.com/stretchr/testify v1.6.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,13 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dijkstracula/go-ilock v0.0.0-20210108024717-0c2939783db9 h1:vPfoMl+6cWGfEMes4ruoKK2Irj7BTKFUvZWMzwROM1E=
+github.com/dijkstracula/go-ilock v0.0.0-20210108024717-0c2939783db9/go.mod h1:tgYmobupvWeZr/U+vhaEjL7Mlc+yl3vxy5EELIPAJDU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tag.go
+++ b/tag.go
@@ -84,7 +84,7 @@ func ParseQualifiedTagName(qtn string) ([]string, error) {
 	var ret []string
 	i := 0
 
-	alpha := "abcdefhijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	alpha := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 	num := "0123456789"
 	alphanum := alpha + num + "_"
 

--- a/taglocker.go
+++ b/taglocker.go
@@ -1,0 +1,283 @@
+package plc
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/dijkstracula/go-ilock"
+)
+
+// TagLockerOperationError is returned when one or more atomic operations on
+// the tag locker in a "serialized" operation have failed. Since a "transaction"
+// on the tag tree can yield multiple errors, a TagLockerFailure is the
+// composition of one or more individual errors.
+type TagLockerOperationError error
+
+func lockError(e error) TagLockerOperationError {
+	return fmt.Errorf("Error locking tag locker: %v", e)
+}
+
+func unlockError(e error) TagLockerOperationError {
+	return fmt.Errorf("Error unlocking tag locker: %v", e)
+}
+
+func rLockError(e error) TagLockerOperationError {
+	return fmt.Errorf("Error read-locking tag locker: %v", e)
+}
+
+func rUnlockError(e error) TagLockerOperationError {
+	return fmt.Errorf("Error read-unlocking tag locker: %v", e)
+}
+
+// TagLocker is a plc.ReadWriter that wraps another ReadWriter, but gates
+// concurrent accesses on grabbing read or write access on a tree of locks
+// representing tag names (in the case of tree leaf nodes) and prefixes of tag
+// names (in the case of tree frond nodes).
+type TagLocker struct {
+	downstream ReadWriter
+	tagTree    *tagLockerNode
+}
+
+// ReadTag reads the given tag name from the downstream ReadWriter. If another
+// thread is concurrently writing to this tag or a prefix of the tag, we will
+// block until that thread has released its access.
+func (tl *TagLocker) ReadTag(name string, value interface{}) (err error) {
+	components, err := ParseQualifiedTagName(name)
+	if err != nil {
+		return
+	}
+
+	err = tl.tagTree.rLock(components)
+	if err != nil {
+		err = rLockError(err)
+		return
+	}
+
+	defer func() {
+		unlockErr := tl.tagTree.rUnlock(components)
+		if unlockErr != nil {
+			err = rUnlockError(unlockErr)
+			return
+		}
+	}()
+
+	err = tl.downstream.ReadTag(name, value)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// WriteTag writes the given tag value to the downstream ReadWriter. Will block
+// if another thread is reading this tag or a prefix of the tag.
+func (tl *TagLocker) WriteTag(name string, value interface{}) (err error) {
+	components, err := ParseQualifiedTagName(name)
+	if err != nil {
+		return
+	}
+
+	err = tl.tagTree.lock(components)
+	if err != nil {
+		err = lockError(err)
+		return
+	}
+
+	defer func() {
+		unlockErr := tl.tagTree.unlock(components)
+		if unlockErr != nil {
+			err = unlockError(unlockErr)
+			return
+		}
+	}()
+
+	err = tl.downstream.WriteTag(name, value)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+type tagLockerNode struct {
+	mtx sync.RWMutex // Ensures mutual exclusion on the fields of the node.
+
+	tagLock   *ilock.Mutex              // The logical lock that mutator threads will hold while reading and writing tags.
+	component string                    // The component of the tag name.
+	children  map[string]*tagLockerNode // All descendents of this node.
+}
+
+// NewTagLocker produces a new TagLocker.
+func NewTagLocker(downstream ReadWriter) *TagLocker {
+	return &TagLocker{
+		downstream: downstream,
+		tagTree:    newNode("/"),
+	}
+}
+
+func newNode(component string) *tagLockerNode {
+	return &tagLockerNode{
+		tagLock:   ilock.New(),
+		mtx:       sync.RWMutex{},
+		component: component,
+		children:  make(map[string]*tagLockerNode),
+	}
+}
+
+// getOrCreate atomically returns the child of `tn` with the supplied
+// component name; or, creates and inserts a child with that name.  In
+// either case, the child in question is returned.
+// Assumes that tn.mtx is _not_ held!
+func (tn *tagLockerNode) getOrCreateChild(component string) *tagLockerNode {
+	tn.mtx.RLock()
+	child, ok := tn.children[component]
+
+	// Do we already have a child component with the current component
+	// name? If so, just recurse on that.
+	if ok {
+		tn.mtx.RUnlock()
+		return child
+	}
+
+	// The child does not exist.  Upgrade to a writer lock in order
+	// to insert a new child into our set of children.
+	tn.mtx.RUnlock()
+	tn.mtx.Lock()
+
+	// Check again to see that nobody beat us to creating that child.
+	child, ok = tn.children[component]
+	if ok {
+		// Lucky us!
+		tn.mtx.Unlock()
+		return child
+	}
+
+	// Okay, we have no choice but to create the child ourselves.
+	child = newNode(component)
+	tn.children[component] = child
+
+	// Release our own lock and recurse on the child.
+	tn.mtx.Unlock()
+	return child
+}
+
+// lock traverses the slice of components, setting intention writer
+// locks along the branch of the lock tree, until it reaches the final
+// tag component.  There, it grabs an exclusive writer lock on that node.
+func (tn *tagLockerNode) lock(components []string) error {
+
+	// If we have no paths to traverse, lock ourselves!
+	if len(components) == 0 {
+		//fmt.Fprintf(os.Stderr, "XLock %v\n", tn.component)
+		tn.tagLock.XLock()
+		return nil
+	}
+
+	// Otherwise, we are only part of the way to the final component
+	// to lock.  Take an intent read lock on this node.
+	//fmt.Fprintf(os.Stderr, "IXLock %v\n", tn.component)
+	tn.tagLock.IXLock()
+
+	currentComp := components[0]
+	remainingComp := components[1:]
+	return tn.getOrCreateChild(currentComp).lock(remainingComp)
+}
+
+// rLock traverses the slice of components, setting intention reader
+// locks along the branch of the lock tree, until it reaches the final
+// tag component.  There, it grabs a reader lock on that node.
+func (tn *tagLockerNode) rLock(components []string) error {
+	// If we have no paths to traverse, lock ourselves!
+	if len(components) == 0 {
+		//fmt.Fprintf(os.Stderr, "SLock %v\n", tn.component)
+		tn.tagLock.SLock()
+		return nil
+	}
+
+	// Otherwise, we are only part of the way to the final component
+	// to lock.  Take an intent read lock on this node.
+	//fmt.Fprintf(os.Stderr, "ISLock %v\n", tn.component)
+	tn.tagLock.ISLock()
+	currentComp := components[0]
+	remainingComp := components[1:]
+
+	return tn.getOrCreateChild(currentComp).rLock(remainingComp)
+}
+
+// rUnlock unlocks a path that has already been previously
+// locked for reader access.  It decrements the reader count on
+// the final component in the path and removes a read intention
+// on all other paths.
+func (tn *tagLockerNode) rUnlock(components []string) error {
+	// If we have no paths to traverse, unlock ourselves!
+	if len(components) == 0 {
+		//fmt.Fprintf(os.Stderr, "SUnLock %v\n", tn.component)
+		tn.tagLock.SUnlock()
+		return nil
+	}
+
+	currentComp := components[0]
+	remainingComp := components[1:]
+
+	defer func() {
+		//fmt.Fprintf(os.Stderr, "ISUnLock %v\n", tn.component)
+		tn.tagLock.ISUnlock()
+	}()
+
+	// Unlock our children first - we want to unlock in the opposite
+	// order that we acquired the locks.
+	tn.mtx.RLock()
+	child, ok := tn.children[currentComp]
+	tn.mtx.RUnlock()
+	if !ok {
+		return fmt.Errorf("missing component %v", currentComp)
+	}
+	err := child.rUnlock(remainingComp)
+	if err != nil {
+		// TODO: what is the right thing to do here?  Should we
+		// attempt to unlock ourselves even if children failed to
+		// unlock correctly?  Either doing so or not doing so seems
+		// dangerous.
+		return err
+	}
+	return nil
+}
+
+// rUnlock unlocks a path that has already been previously
+// locked for writer access.  It decrements the writer count on
+// the final component in the path and removes a write intention
+// on all other paths.
+func (tn *tagLockerNode) unlock(components []string) error {
+	// If we have no paths to traverse, unlock ourselves!
+	if len(components) == 0 {
+		//fmt.Fprintf(os.Stderr, "XUnLock %v\n", tn.component)
+		tn.tagLock.XUnlock()
+		return nil
+	}
+
+	currentComp := components[0]
+	remainingComp := components[1:]
+
+	defer func() {
+		//fmt.Fprintf(os.Stderr, "IXUnLock %v\n", tn.component)
+		tn.tagLock.IXUnlock()
+	}()
+
+	// Unlock our children first - we want to unlock in the opposite
+	// order that we acquired the locks.
+	tn.mtx.RLock()
+	child, ok := tn.children[currentComp]
+	tn.mtx.RUnlock()
+	if !ok {
+		return fmt.Errorf("missing component %v", currentComp)
+	}
+	err := child.unlock(remainingComp)
+	if err != nil {
+		// TODO: what is the right thing to do here?  Should we
+		// attempt to unlock ourselves even if children failed to
+		// unlock correctly?  Either doing so or not doing so seems
+		// dangerous.
+		return err
+	}
+	return nil
+}

--- a/taglocker_test.go
+++ b/taglocker_test.go
@@ -1,0 +1,211 @@
+package plc
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"sync"
+	"testing"
+)
+
+const alphaCharset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+const numCharset = "0123456789"
+const alphanumCharset = alphaCharset + "_" + numCharset
+
+// mockReadWriter is a dummy ReadWriter interface that unconditionally succeeds.  We
+// protect concurrenct accesses to the `state` map but _not_ the memory that the map's
+// value points to, so it has to be the responsibility of the caller of ReadTag and
+// WriteTag to ensure mutual exclusion on _their_ accesses.
+type mockReadWriter struct {
+	state map[string]*uint32 // State is read/written to for the benefit of the race detector during unit tests.
+	mtx   sync.Mutex
+}
+
+var _ = ReadWriter(&TagLocker{})
+
+func newMockReadWriter() *mockReadWriter {
+	return &mockReadWriter{
+		state: make(map[string]*uint32),
+	}
+}
+func (norw *mockReadWriter) ReadTag(name string, value interface{}) error {
+	//fmt.Fprintf(os.Stderr, "Downstream: Reading %v\n", name)
+
+	norw.mtx.Lock()
+	ptr, ok := norw.state[name]
+	if !ok {
+		ptr = new(uint32)
+		norw.state[name] = ptr
+	}
+	norw.mtx.Unlock()
+
+	value = *ptr
+
+	return nil
+}
+func (norw *mockReadWriter) WriteTag(name string, value interface{}) error {
+	//fmt.Fprintf(os.Stderr, "Downstream: Writing %v\n", name)
+
+	norw.mtx.Lock()
+	ptr, ok := norw.state[name]
+	if !ok {
+		ptr = new(uint32)
+		norw.state[name] = ptr
+	}
+	norw.mtx.Unlock()
+
+	*ptr++
+
+	return nil
+}
+
+// Generates a random fully-qualified tag, and returns
+// paths to that tag but also all intermediary prefixes.
+// We will test that we can lock intermediary nodes by
+// randomly choosing from these returned values.
+func genPaths() []string {
+	var paths []string
+
+	/*
+	* The EBNF is:
+	*
+	* tag ::= SYMBOLIC_SEG ( tag_seg )* ( bit_seg )?
+	*
+	* tag_seg ::= '.' SYMBOLIC_SEG
+	*             '[' array_seg ']'
+	*
+	* bit_seg ::= '.' [0-9]+
+	*
+	* array_seg ::= NUMERIC_SEG ( ',' NUMERIC_SEG )*
+	*
+	* SYMBOLIC_SEG ::= [a-zA-Z]([a-zA-Z0-9_]*)
+	*
+	* NUMERIC_SEG ::= [0-9]+
+	*
+	 */
+	genSymbolicSeg := func() string {
+		length := 1 + rand.Intn(10)
+		bs := make([]byte, length)
+		bs[0] = alphaCharset[rand.Intn(len(alphaCharset))]
+		for i := 1; i < len(bs); i++ {
+			bs[i] = alphanumCharset[rand.Intn(len(alphanumCharset))]
+		}
+		return string(bs)
+	}
+
+	genNumericSeg := func() string {
+		return fmt.Sprintf("%d", rand.Intn(10))
+	}
+	genArraySeg := func() string {
+		// TODO: when the parser supports comma-separated multidimensional
+		// arrays, include potentially generating those.
+		return genNumericSeg()
+	}
+	genTagSeg := func() string {
+		if rand.Intn(2) == 0 {
+			return "." + genSymbolicSeg()
+		}
+		return fmt.Sprintf("[%s]", genArraySeg())
+	}
+	// tag ::= SYMBOLIC_SEG ( tag_seg )* ( bit_seg )?
+	var sb strings.Builder
+	sb.WriteString(genSymbolicSeg())
+	for i := 0; i < rand.Intn(5); i++ {
+		//paths = append(paths, sb.String())
+		sb.WriteString(genTagSeg())
+	}
+	paths = append(paths, sb.String())
+	return paths
+}
+
+const serialConcurrency = 1
+const lowConcurrency = 10
+const medConcurrency = 20
+const highConcurrency = 30
+const writePerc = 1
+const heavyWritePerc = 50
+
+const numTags = 10
+
+func BenchmarkSerialTagLocking(b *testing.B) {
+	benchmarkTagLockLocking(b, serialConcurrency, writePerc)
+}
+
+func BenchmarkLowConcurrencyTagLocking(b *testing.B) {
+	benchmarkTagLockLocking(b, lowConcurrency, writePerc)
+}
+
+func BenchmarkMedConcurrencyTagLocking(b *testing.B) {
+	benchmarkTagLockLocking(b, medConcurrency, writePerc)
+}
+
+func BenchmarkHighConcurrencyTagLocking(b *testing.B) {
+	benchmarkTagLockLocking(b, highConcurrency, writePerc)
+}
+
+func BenchmarkSerialTagLockingWithHeavyWrites(b *testing.B) {
+	benchmarkTagLockLocking(b, serialConcurrency, heavyWritePerc)
+}
+
+func BenchmarkLowConcurrencyTagLockingWithHeavyWrites(b *testing.B) {
+	benchmarkTagLockLocking(b, lowConcurrency, heavyWritePerc)
+}
+
+func BenchmarkMedConcurrencyTagLockingWithHeavyWrites(b *testing.B) {
+	benchmarkTagLockLocking(b, medConcurrency, heavyWritePerc)
+}
+func BenchmarkHighConcurrencyTagLockingWithHeavyWrites(b *testing.B) {
+	benchmarkTagLockLocking(b, highConcurrency, heavyWritePerc)
+}
+
+func benchmarkTagLockLocking(b *testing.B, concurrency int, writePerc int) {
+	barrier := make(chan bool, concurrency)
+
+	tl := NewTagLocker(newMockReadWriter())
+
+	read := func(name string) {
+		var garbage uint32
+
+		err := tl.ReadTag(name, garbage)
+		if err != nil {
+			b.Errorf("%v\n", err)
+		}
+		<-barrier
+	}
+	write := func(name string) {
+		err := tl.WriteTag(name, 42)
+		if err != nil {
+			b.Errorf("%v\n", err)
+		}
+		<-barrier
+	}
+
+	// Generate `numTags` randomly-named tags; the slice of tags
+	// stores those tags but also all intermediary prefixes to
+	// those tags, so larger structures can be locked.
+	var tags []string
+	for i := 0; i < numTags; i++ {
+		tags = append(tags, genPaths()...)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tag := tags[rand.Intn(len(tags))]
+		isWrite := rand.Intn(100) < writePerc
+
+		barrier <- true
+		if isWrite {
+			go write(tag)
+		} else {
+			go read(tag)
+		}
+	}
+	for {
+		select {
+		case <-barrier:
+		default:
+			b.StopTimer()
+			return
+		}
+	}
+}


### PR DESCRIPTION
    TagLocker ReadWriter impl

    This patch includes an implementation of a plc.ReadWriter that
    gates access on a downstream ReadWriter through intention locking
    on each of the given tag name's components.

    The benchmark results for this implementation follow:

    BenchmarkSerialTagLocking
    BenchmarkSerialTagLocking-12                                      292084              4155 ns/op
    BenchmarkLowConcurrencyTagLocking
    BenchmarkLowConcurrencyTagLocking-12                             1337608               916 ns/op
    BenchmarkMedConcurrencyTagLocking
    BenchmarkMedConcurrencyTagLocking-12                             1889516               657 ns/op
    BenchmarkHighConcurrencyTagLocking
    BenchmarkHighConcurrencyTagLocking-12                            1850548               651 ns/op
    BenchmarkSerialTagLockingWithHeavyWrites
    BenchmarkSerialTagLockingWithHeavyWrites-12                       271552              3702 ns/op
    BenchmarkLowConcurrencyTagLockingWithHeavyWrites
    BenchmarkLowConcurrencyTagLockingWithHeavyWrites-12              1304198              1064 ns/op
    BenchmarkMedConcurrencyTagLockingWithHeavyWrites
    BenchmarkMedConcurrencyTagLockingWithHeavyWrites-12              1655668               723 ns/op
    BenchmarkHighConcurrencyTagLockingWithHeavyWrites
    BenchmarkHighConcurrencyTagLockingWithHeavyWrites-12             1753326               751 ns/op
    PASS

    As expected, throughput increases when we add a degree of concurrency, but it
    seems to level out pretty quickly.  Unsurprisingly, as well, the intention
    write locks seem to decrease throughput slightly as readers will be unable
    to grab intention read locks on interior nodes until those operations complete.
