### PR TITLE
Get tags with types

### DIFF
--- a/example/get-tags/main.go
+++ b/example/get-tags/main.go
@@ -17,6 +17,8 @@ func main() {
 
 	plc.SetLibplctagDebug(plc.LibplctagDebugLevel(*plcDebug))
 
+	panicIfError(registerTagTypes(), "Couldn't register tag types")
+
 	device, err := plc.NewDevice(*addr)
 	panicIfError(err, "Could not create test PLC!")
 	defer func() {
@@ -35,6 +37,11 @@ func main() {
 	panicIfError(err, "Could not get PLC programs!")
 
 	fmt.Println("Programs:", programs)
+}
+
+func registerTagTypes() error {
+	// Add the dummy tag type
+	return plc.RegisterTagTypeName(0x2000, "dummy_tag_type")
 }
 
 func panicIfError(err error, reason string) {

--- a/example/get-tags/tags.csv
+++ b/example/get-tags/tags.csv
@@ -1,0 +1,1 @@
+2000,dummy_tag_type

--- a/example/get-tags/tags.csv
+++ b/example/get-tags/tags.csv
@@ -1,1 +1,1 @@
-2000,dummy_tag_type
+2001,dummy_unused

--- a/example/read-all-tags/main.go
+++ b/example/read-all-tags/main.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"reflect"
+
+	"github.com/stellentus/go-plc"
+)
+
+var (
+	addr     = flag.String("address", "192.168.1.176", "Hostname or IP address of the PLC")
+	plcDebug = flag.Int("plctagdebug", 0, "Debug level for libplctag's debug (0-5)")
+)
+
+func main() {
+	flag.Parse()
+
+	plc.SetLibplctagDebug(plc.LibplctagDebugLevel(*plcDebug))
+
+	device, err := plc.NewDevice(*addr)
+	panicIfError(err, "Could not create test PLC!")
+	defer func() {
+		err := device.Close()
+		if err != nil {
+			fmt.Println("Close was unsuccessful:", err.Error())
+		}
+	}()
+
+	tags, err := device.GetAllTags()
+	panicIfError(err, "Could not get PLC tags!")
+
+	for _, tag := range tags {
+		if !tag.CanBeInstantiated() {
+			fmt.Printf("Cannot instantiate %v\n", tag)
+			continue
+		}
+
+		newVal, err := tag.NewInstance()
+		panicIfError(err, "Couldn't instantiate "+tag.Name())
+
+		err = device.ReadTag(tag.Name(), newVal)
+		switch {
+		case errors.Is(err, plc.Pending):
+			fmt.Printf("Tag %v is pending (%v)\n", tag, err)
+		case errors.Is(err, plc.ErrBadRequest):
+			fmt.Printf("Tag %v was a bad request (%v)\n", tag, err)
+		case errors.Is(err, plc.ErrPlcConnection):
+			fmt.Printf("Tag %v encountered a connection error (%v)\n", tag, err)
+		case errors.Is(err, plc.ErrPlcInternal):
+			fmt.Printf("Tag %v encountered an internal PLC error (%v)\n", tag, err)
+		case err != nil:
+			panicIfError(err, fmt.Sprintf("Couldn't read %v", tag))
+		default:
+			fmt.Printf("%s is %v (type: %s)\n", tag.Name(), reflect.ValueOf(newVal).Elem(), tag.TagType.String())
+		}
+	}
+}
+
+func panicIfError(err error, reason string) {
+	if err != nil {
+		panic("ERROR '" + err.Error() + "': " + reason)
+	}
+}

--- a/libplctag_stub.go
+++ b/libplctag_stub.go
@@ -7,3 +7,11 @@ package plc
 #include <libplctag.h>
 */
 import "C"
+
+const dummyTagType = 0x2000
+
+func init() {
+	// The stub uses type 0x2000 for everything. The pre-loaded ones are uint16.
+	RegisterTagTypeName(dummyTagType, "dummy_type")
+	RegisterTagType(dummyTagType, uint16(0))
+}

--- a/libplctagdevice.go
+++ b/libplctagdevice.go
@@ -344,7 +344,7 @@ func (dev *libplctagDevice) GetList(listName, prefix string) ([]Tag, []string, e
 		tag := Tag{}
 		offset += 4
 
-		tag.tagType = uint16(C.plc_tag_get_uint16(id, offset))
+		tag.TagType = TagType(C.plc_tag_get_uint16(id, offset))
 		offset += 2
 
 		tag.elementSize = uint16(C.plc_tag_get_uint16(id, offset))
@@ -374,10 +374,10 @@ func (dev *libplctagDevice) GetList(listName, prefix string) ([]Tag, []string, e
 
 		if strings.HasPrefix(tag.name, "Program:") {
 			programNames = append(programNames, tag.name)
-		} else if (tag.tagType & SystemTagBit) == SystemTagBit {
+		} else if (tag.TagType & SystemTagBit) == SystemTagBit {
 			// Do nothing for system tags
 		} else {
-			numDimensions := int((tag.tagType & TagDimensionMask) >> 13)
+			numDimensions := int((tag.TagType & TagDimensionMask) >> 13)
 			if numDimensions != len(tag.dimensions) {
 				return nil, nil, fmt.Errorf("GetList: %w: tag '%s' claims to have %d dimensions but has %d", ErrPlcInternal, tag.name, numDimensions, len(tag.dimensions))
 			}

--- a/tag.go
+++ b/tag.go
@@ -242,6 +242,17 @@ func (tt TagType) String() string {
 	return fmt.Sprintf("%04X", uint16(tt))
 }
 
+// NewInstance returns a pointer to a new variable of the TagType.
+// This can be passed directly into ReadTag to read the value.
+func (tt TagType) NewInstance() (interface{}, error) {
+	rtyp, ok := tagTypes[tt]
+	if !ok {
+		return nil, fmt.Errorf("no instance of %s has been registered", tt.String())
+	}
+
+	return reflect.New(rtyp).Interface(), nil
+}
+
 func (tt TagType) HasName() bool {
 	_, ok := tagTypeNames[tt]
 	return ok

--- a/tag.go
+++ b/tag.go
@@ -290,10 +290,10 @@ func (tt TagType) CanBeInstantiated() bool {
 }
 
 var tagTypes = map[TagType]reflect.Type{
-	0x00C1: reflect.TypeOf(Bool(false)),
-	0x00C2: reflect.TypeOf(Sint(0)),
-	0x00CA: reflect.TypeOf(Real(0)),
-	0x20C4: reflect.TypeOf(Dint(0)),
+	0x00C1: reflect.TypeOf(false),
+	0x00C2: reflect.TypeOf(uint16(0)), // TODO perhaps this should be signed?
+	0x00CA: reflect.TypeOf(float32(0)),
+	0x20C4: reflect.TypeOf(uint32(0)), // TODO perhaps this should be signed?
 }
 
 // RegisterTagType registers the provided variable as the type of the provided TagType.
@@ -318,8 +318,3 @@ func RegisterTagType(tt TagType, instanceOfType interface{}) error {
 
 	return nil
 }
-
-type Bool bool
-type Sint uint16 // TODO perhaps this should be signed?
-type Real float32
-type Dint uint32 // TODO perhaps this should be signed?

--- a/tag.go
+++ b/tag.go
@@ -261,7 +261,34 @@ func (tt TagType) HasName() bool {
 var tagTypeNames = map[TagType]string{
 	0x00C1: "BOOL",
 	0x00C2: "SINT",
+	0x00C3: "INT",
+	0x00C4: "DINT",
+	0x00C5: "LINT",
+	0x00C6: "USINT",
+	0x00C7: "UINT",
+	0x00C8: "UDINT",
+	0x00C9: "ULINT",
 	0x00CA: "REAL",
+	0x00CB: "LREAL",
+	0x00CC: "STIME",
+	0x00CD: "DATE",
+	0x00CE: "TIME_OF_DAY",
+	0x00CF: "DATE_AND_TIME",
+	0x00D0: "STRING",
+	0x00D1: "BYTE",
+	0x00D2: "WORD",
+	0x00D3: "DWORD",
+	0x00D4: "LWORD",
+	0x00D5: "STRING2",
+	0x00D6: "FTIME",
+	0x00D7: "LTIME",
+	0x00D8: "ITIME",
+	0x00D9: "STRINGN",
+	0x00DA: "SHORT_STRING",
+	0x00DB: "TIME",
+	0x00DC: "EPATH",
+	0x00DD: "ENGUNIT",
+	0x20C3: "INT",
 	0x20C4: "DINT",
 }
 
@@ -291,9 +318,36 @@ func (tt TagType) CanBeInstantiated() bool {
 
 var tagTypes = map[TagType]reflect.Type{
 	0x00C1: reflect.TypeOf(false),
-	0x00C2: reflect.TypeOf(uint16(0)), // TODO perhaps this should be signed?
+	0x00C2: reflect.TypeOf(int8(0)),
+	0x00C3: reflect.TypeOf(int16(0)),
+	0x00C4: reflect.TypeOf(int32(0)),
+	0x00C5: reflect.TypeOf(int64(0)),
+	0x00C6: reflect.TypeOf(uint8(0)),
+	0x00C7: reflect.TypeOf(uint16(0)),
+	0x00C8: reflect.TypeOf(uint32(0)),
+	0x00C9: reflect.TypeOf(uint64(0)),
 	0x00CA: reflect.TypeOf(float32(0)),
-	0x20C4: reflect.TypeOf(uint32(0)), // TODO perhaps this should be signed?
+	0x00CB: reflect.TypeOf(float64(0)),
+	// 0x00CC: reflect.TypeOf(SynchronousTime{}), // unsupported
+	// 0x00CD: reflect.TypeOf(Date{}), // unsupported
+	// 0x00CE: reflect.TypeOf(TimeOfDay{}), // unsupported
+	// 0x00CF: reflect.TypeOf(DateTime{}), // unsupported
+	0x00D0: reflect.TypeOf(string("")),
+	0x00D1: reflect.TypeOf(byte(0)),   // might not be correct; might be an array
+	0x00D2: reflect.TypeOf(uint16(0)), // might not be correct; might be an array
+	0x00D3: reflect.TypeOf(uint32(0)), // might not be correct; might be an array
+	0x00D4: reflect.TypeOf(uint64(0)), // might not be correct; might be an array
+	// 0x00D5: reflect.TypeOf(String2Byte{}), //unsupported
+	// 0x00D6: reflect.TypeOf(DurationHigh{}), //unsupported, but uses int32
+	// 0x00D7: reflect.TypeOf(DurationLong{}), //unsupported, but uses int64
+	// 0x00D8: reflect.TypeOf(DurationShort{}), //unsupported
+	// 0x00D9: reflect.TypeOf(CharStringNBytesPerCharacter{}), //unsupported
+	// 0x00DA: reflect.TypeOf(CharacterSTringWithLengthByte{}), //unsupported
+	// 0x00DB: reflect.TypeOf(Duration_ms{}), //unsupported
+	// 0x00DC: reflect.TypeOf(CipPathSegments{}), //unsupported
+	// 0x00DD: reflect.TypeOf(EngineeringUnits{}), //unsupported
+	0x20C3: reflect.TypeOf(int32(0)), // might actually be unsigned or 16 bits?
+	0x20C4: reflect.TypeOf(int32(0)),
 }
 
 // RegisterTagType registers the provided variable as the type of the provided TagType.

--- a/tag.go
+++ b/tag.go
@@ -9,8 +9,8 @@ import (
 )
 
 type Tag struct {
-	name        string
-	tagType     uint16
+	name string
+	TagType
 	elementSize uint16
 	dimensions  []int
 }
@@ -27,7 +27,7 @@ func (tag *Tag) addDimension(dim int) {
 }
 
 func (tag Tag) String() string {
-	name := fmt.Sprintf("%s{%04X}", tag.name, int(tag.tagType))
+	name := fmt.Sprintf("%s{%v}", tag.name, tag.TagType)
 
 	if len(tag.dimensions) == 0 {
 		return name
@@ -227,4 +227,10 @@ func ParseQualifiedTagName(qtn string) ([]string, error) {
 	}
 
 	return ret, nil
+}
+
+type TagType uint16
+
+func (tt TagType) String() string {
+	return fmt.Sprintf("%04X", uint16(tt))
 }

--- a/tag.go
+++ b/tag.go
@@ -232,5 +232,34 @@ func ParseQualifiedTagName(qtn string) ([]string, error) {
 type TagType uint16
 
 func (tt TagType) String() string {
+	if name, ok := tagTypeNames[tt]; ok {
+		return name
+	}
 	return fmt.Sprintf("%04X", uint16(tt))
+}
+
+func (tt TagType) HasName() bool {
+	_, ok := tagTypeNames[tt]
+	return ok
+}
+
+var tagTypeNames = map[TagType]string{}
+
+// RegisterTagTypeName registers the provided string as the name of the provided TagType.
+// It returns an error if the TagType has already been registered with a different string,
+// but it does not check if the string is unique.
+func RegisterTagTypeName(tt TagType, name string) error {
+	if name == "" {
+		return fmt.Errorf("Cannot register empty string for TagType{%04X}", tt)
+	}
+
+	prevName, ok := tagTypeNames[tt]
+	if ok { // tt is already registered
+		if prevName == name {
+			return nil // same string; do nothing
+		}
+		return fmt.Errorf("Cannot register string '%s' for TagType{%04X} with '%s' already registered", name, tt, prevName)
+	}
+	tagTypeNames[tt] = name
+	return nil
 }

--- a/tag.go
+++ b/tag.go
@@ -243,7 +243,12 @@ func (tt TagType) HasName() bool {
 	return ok
 }
 
-var tagTypeNames = map[TagType]string{}
+var tagTypeNames = map[TagType]string{
+	0x00C1: "BOOL",
+	0x00C2: "SINT",
+	0x00CA: "REAL",
+	0x20C4: "DINT",
+}
 
 // RegisterTagTypeName registers the provided string as the name of the provided TagType.
 // It returns an error if the TagType has already been registered with a different string,

--- a/tag_test.go
+++ b/tag_test.go
@@ -3,6 +3,9 @@ package plc
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var parserTests = []struct {
@@ -69,4 +72,35 @@ func TestParser(t *testing.T) {
 			}
 		}
 	}
+}
+
+var testTagType = TagType(0x7738)
+var testTagTypeName = "testTagType"
+
+func TestTagTypeString(t *testing.T) {
+	assert.Equal(t, "7738", testTagType.String())
+}
+
+func TestTagTypeHasNoName(t *testing.T) {
+	assert.False(t, testTagType.HasName(), "unregistered type has no name")
+}
+
+func TestRegisterTagType(t *testing.T) {
+	err := RegisterTagTypeName(testTagType, testTagTypeName)
+	require.NoError(t, err)
+	assert.Equal(t, testTagTypeName, testTagType.String(), "Name should be updated if registered")
+}
+
+func TestRegisterDuplicateTagType(t *testing.T) {
+	err := RegisterTagTypeName(testTagType, testTagTypeName)
+	require.NoError(t, err)
+	err = RegisterTagTypeName(testTagType, testTagTypeName)
+	assert.NoError(t, err)
+}
+
+func TestRegisterTwoStringsOneTag(t *testing.T) {
+	err := RegisterTagTypeName(testTagType, testTagTypeName)
+	require.NoError(t, err)
+	err = RegisterTagTypeName(testTagType, testTagTypeName+"DifferentString")
+	assert.Error(t, err)
 }

--- a/tag_test.go
+++ b/tag_test.go
@@ -1,6 +1,7 @@
 package plc
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -76,6 +77,7 @@ func TestParser(t *testing.T) {
 
 func resetRegistration() {
 	tagTypeNames = map[TagType]string{}
+	tagTypes = map[TagType]reflect.Type{}
 }
 
 var testTagType = TagType(0x7738)
@@ -89,14 +91,14 @@ func TestTagTypeHasNoName(t *testing.T) {
 	assert.False(t, testTagType.HasName(), "unregistered type has no name")
 }
 
-func TestRegisterTagType(t *testing.T) {
+func TestRegisterTagTypeString(t *testing.T) {
 	resetRegistration()
 	err := RegisterTagTypeName(testTagType, testTagTypeName)
 	require.NoError(t, err)
 	assert.Equal(t, testTagTypeName, testTagType.String(), "Name should be updated if registered")
 }
 
-func TestRegisterDuplicateTagType(t *testing.T) {
+func TestRegisterDuplicateTagTypeString(t *testing.T) {
 	resetRegistration()
 	err := RegisterTagTypeName(testTagType, testTagTypeName)
 	require.NoError(t, err)
@@ -109,5 +111,33 @@ func TestRegisterTwoStringsOneTag(t *testing.T) {
 	err := RegisterTagTypeName(testTagType, testTagTypeName)
 	require.NoError(t, err)
 	err = RegisterTagTypeName(testTagType, testTagTypeName+"DifferentString")
+	assert.Error(t, err)
+}
+
+func TestUnregisteredTagTypeCannotBeInstantiated(t *testing.T) {
+	resetRegistration()
+	assert.False(t, testTagType.CanBeInstantiated(), "Cannot instantiate unregistered tag type")
+}
+
+func TestRegisterTagTypeCanBeInstantiated(t *testing.T) {
+	resetRegistration()
+	err := RegisterTagType(testTagType, int(0))
+	require.NoError(t, err)
+	assert.True(t, testTagType.CanBeInstantiated(), "Can instantiate registered tag type")
+}
+
+func TestRegisterDuplicateTagType(t *testing.T) {
+	resetRegistration()
+	err := RegisterTagType(testTagType, int(0))
+	require.NoError(t, err)
+	err = RegisterTagType(testTagType, int(0))
+	assert.NoError(t, err)
+}
+
+func TestRegisterTwoTypesOneTag(t *testing.T) {
+	resetRegistration()
+	err := RegisterTagType(testTagType, int(0))
+	require.NoError(t, err)
+	err = RegisterTagType(testTagType, int32(0))
 	assert.Error(t, err)
 }

--- a/tag_test.go
+++ b/tag_test.go
@@ -74,6 +74,10 @@ func TestParser(t *testing.T) {
 	}
 }
 
+func resetRegistration() {
+	tagTypeNames = map[TagType]string{}
+}
+
 var testTagType = TagType(0x7738)
 var testTagTypeName = "testTagType"
 
@@ -86,12 +90,14 @@ func TestTagTypeHasNoName(t *testing.T) {
 }
 
 func TestRegisterTagType(t *testing.T) {
+	resetRegistration()
 	err := RegisterTagTypeName(testTagType, testTagTypeName)
 	require.NoError(t, err)
 	assert.Equal(t, testTagTypeName, testTagType.String(), "Name should be updated if registered")
 }
 
 func TestRegisterDuplicateTagType(t *testing.T) {
+	resetRegistration()
 	err := RegisterTagTypeName(testTagType, testTagTypeName)
 	require.NoError(t, err)
 	err = RegisterTagTypeName(testTagType, testTagTypeName)
@@ -99,6 +105,7 @@ func TestRegisterDuplicateTagType(t *testing.T) {
 }
 
 func TestRegisterTwoStringsOneTag(t *testing.T) {
+	resetRegistration()
 	err := RegisterTagTypeName(testTagType, testTagTypeName)
 	require.NoError(t, err)
 	err = RegisterTagTypeName(testTagType, testTagTypeName+"DifferentString")


### PR DESCRIPTION
* Prefix all tags with their program name in `GetAllTags`
* Allow a type to be registered for each CIP data type (e.g. 0x00C3 is "INT", which is a go `int16`).
* Allow an instance of a tag to be created by looking at its CIP type (e.g. the stub uses 0x2000 for `DUMMY_AQUA_DATA_0` of type `uint16`. If we know that a given `tag` has type 0x2000, we can call `tag.NewInstance()` to return a new variable of type `uint16`.)
* Update `example/get-tags` to display the tag's type (using a pretty name like `dummy_tag_type` if known; else resort to the number, like 0x2000)
* Implement `example/read-all-tags`.  First, use `GetAllTags` to learn the type of each tag. Then create an instance of each tag's type and read its value.
* This relies on #5 to print better error messages

This has been tested on the plant.