### PR TITLE
Fix tag struct prefix

### DIFF
--- a/l5x/type.go
+++ b/l5x/type.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"strings"
 	"unicode"
+
+	"github.com/stellentus/go-plc"
 )
 
 type Type interface {
@@ -530,7 +532,7 @@ func (sti structType) GoTypeString() string {
 	for i, member := range sti.members {
 		tagSuffix := ""
 		if member.PlcName != "" {
-			tagSuffix = " `plc:\"" + member.PlcName + "\"`"
+			tagSuffix = fmt.Sprintf(" `%s:\"%s\"`", plc.TagPrefix, member.PlcName)
 		}
 		strs[i] = fmt.Sprintf("\n\t%s%s", NamedTypeDeclaration(member), tagSuffix)
 	}

--- a/l5x/type_test.go
+++ b/l5x/type_test.go
@@ -284,7 +284,7 @@ func ExampleTypeList_WriteDefinitions() {
 	// 	BHAIG29GI TIMER
 	// 	COUNTDOWN_TO_DESSERT TIMER
 	// 	STEPS_REQUIRED int16
-	// 	SoMuchData Big_data_type `plc:"soMuchData"`
+	// 	SoMuchData Big_data_type `plctag:"soMuchData"`
 	// }
 	//
 	// type EVENT_TOT struct {
@@ -417,7 +417,7 @@ func TestDataTypeAsNamedType(t *testing.T) {
 	)
 	runTest(
 		"SimpleStruct",
-		"struct {\n\tVarName int16\n\tMY_VAR float32\n\tOtherVar int8 `plc:\"otherVar\"`\n}",
+		"struct {\n\tVarName int16\n\tMY_VAR float32\n\tOtherVar int8 `plctag:\"otherVar\"`\n}",
 		func(dt *DataType) {
 			dt.Members = append(dt.Members, newTestMember("MY_VAR", "REAL"))
 			dt.Members = append(dt.Members, newTestMember("otherVar", "SINT"))
@@ -437,7 +437,7 @@ func TestDataTypeAsNamedType(t *testing.T) {
 	)
 	runTest(
 		"SimpleStruct",
-		"struct {\n\tVarName int16\n\tBad_name__ float32 `plc:\"bad name 💔\"`\n}",
+		"struct {\n\tVarName int16\n\tBad_name__ float32 `plctag:\"bad name 💔\"`\n}",
 		func(dt *DataType) {
 			dt.Members = append(dt.Members, newTestMember("bad name 💔", "REAL"))
 		},
@@ -470,14 +470,14 @@ func TestDataTypeAsNamedTypePredeclared(t *testing.T) {
 
 	runTest(
 		"IncludeRegisteredType",
-		"struct {\n\tVarName int16\n\tOtherVar RegisteredType `plc:\"otherVar\"`\n}",
+		"struct {\n\tVarName int16\n\tOtherVar RegisteredType `plctag:\"otherVar\"`\n}",
 		func(dt *DataType) {
 			dt.Members = append(dt.Members, newTestMember("otherVar", "RegisteredType"))
 		},
 	)
 	runTest(
 		"TIMER",
-		"struct {\n\tTimerVar TIMER `plc:\"timerVar\"`\n}",
+		"struct {\n\tTimerVar TIMER `plctag:\"timerVar\"`\n}",
 		func(dt *DataType) {
 			dt.Members = []Member{newTestMember("timerVar", "TIMER")}
 		},

--- a/l5x/xml_test.go
+++ b/l5x/xml_test.go
@@ -1050,12 +1050,12 @@ func ExampleController_WriteTagsStruct() {
 	// type Dancer struct {
 	// 	DOW Dow
 	// 	EX_AOI EVENT_TOT
-	// 	MultiArray [2][4]int16 `plc:"multiArray"`
+	// 	MultiArray [2][4]int16 `plctag:"multiArray"`
 	// }
 	//
 	// type EXAMPLE_FACTORY struct {
 	// 	INFO_ABOUT [2]int16
-	// 	BIGGD Big_data_type `plc:"bIGGD"`
-	// 	Dancer `plc:"Program:dancer"`
+	// 	BIGGD Big_data_type `plctag:"bIGGD"`
+	// 	Dancer `plctag:"Program:dancer"`
 	// }
 }

--- a/splitter.go
+++ b/splitter.go
@@ -6,6 +6,10 @@ import (
 	"strings"
 )
 
+// TagPrefix is the prefix used for struct tags.
+// Note the use of the word 'tag' in the prefix itself refers to PLC tags, not go tags.
+const TagPrefix = "plctag"
+
 // SplitReader splits reads of structs, arrays, and slices into separate reads of their components.
 // It is important to note that ReadTag will attempt to read or write a slice or array up to its length.
 // This might cause a PLC error if the operation goes out of bounds.
@@ -147,7 +151,7 @@ func (sw SplitWriter) WriteTag(name string, value interface{}) error {
 // allowOmitEmpty is true.
 func getNameOfField(str reflect.Value, i int, allowOmitEmpty bool) (string, bool) {
 	field := str.Type().Field(i)
-	plctag := field.Tag.Get("plctag")
+	plctag := field.Tag.Get(TagPrefix)
 	if plctag == "" {
 		return field.Name, true
 	}


### PR DESCRIPTION
It turns out I was using a different prefix in different places (`plc` and `plctag`). Now it's a `const`.