### PR TITLE
tag parser: trim "Program:" prefix

### DIFF
--- a/tag.go
+++ b/tag.go
@@ -77,7 +77,7 @@ func ParseQualifiedTagName(qtn string) ([]string, error) {
 	var ret []string
 	i := 0
 
-	alpha := "abcdefhijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	alpha := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 	num := "0123456789"
 	alphanum := alpha + num + "_"
 
@@ -204,6 +204,14 @@ func ParseQualifiedTagName(qtn string) ([]string, error) {
 		return nil
 	}
 
+	/* If the tag begins with "Program:", drop that prefix; we will append it
+	 * to the starting symbolic segment before returning.  */
+	var hadProgramPrefix bool
+	if strings.HasPrefix(qtn, "Program:") {
+		hadProgramPrefix = true
+		qtn = strings.TrimPrefix(qtn, "Program:")
+	}
+
 	/* Check position-independent invariants: the tagname must be nonempty and
 	 * must only contain alphanumeric characters.
 	 */
@@ -224,6 +232,10 @@ func ParseQualifiedTagName(qtn string) ([]string, error) {
 		if err := parseTagSegment(); err != nil {
 			return nil, err
 		}
+	}
+
+	if hadProgramPrefix {
+		ret[0] = "Program:" + ret[0]
 	}
 
 	return ret, nil

--- a/tag_test.go
+++ b/tag_test.go
@@ -37,6 +37,12 @@ var parserTests = []struct {
 	{"ARRAY[0,1,2]", []string{"ARRAY", "0", "1", "2"}, ""},
 	{"ARRAY[ 0 ,  1  , 2 ]", []string{"ARRAY", "0", "1", "2"}, ""},
 	{"Field.Array[42].Member[16]", []string{"Field", "Array", "42", "Member", "16"}, ""},
+
+	// Special case: "Program:" is a valid prefix to begin a tag.  Merge the top-level tag and "Program" into one "tag".
+	{"Program:Field.Array[42].Member[16]", []string{"Program:Field", "Array", "42", "Member", "16"}, ""},
+	{"Program::Field.Array[42].Member[16]", nil, "non-alphabetic character ':'"},
+	{"Field.Program:Array[42].Member[16]", nil, "expected '.' or '['; got ':'"},
+	{"Program:", nil, "Empty tagname"},
 }
 
 func compareStrSlices(s1, s2 []string) bool {


### PR DESCRIPTION
Technically, the colon in "Program:" causes the tag parser to fail
since it's an invalid character.  Special-case the parser to drop
this prefix if it's present.