### PR TITLE
Async splitreader

### DIFF
--- a/async.go
+++ b/async.go
@@ -1,0 +1,136 @@
+package plc
+
+import (
+	"golang.org/x/sync/errgroup"
+)
+
+type asyncer interface {
+	Wait() error
+	Add(name string, value interface{})
+	AddError(err error)
+}
+
+type action func(string, interface{}) error
+
+type job struct {
+	name  string
+	value interface{}
+}
+
+var noJob = job{}
+
+type async struct {
+	action
+	*errgroup.Group
+	jobs        chan job
+	numRoutines int
+}
+
+func newAsync(act action) async {
+	as := async{
+		action:      act,
+		Group:       &errgroup.Group{},
+		jobs:        make(chan job, 1),
+		numRoutines: 1,
+	}
+
+	as.launchRoutine(noJob)
+
+	go func() {
+		// Listen for new jobs and launch them in new goroutines until the limit has been reached.
+		for newJob := range as.jobs {
+			as.numRoutines++
+			as.launchRoutine(newJob)
+		}
+	}()
+
+	return as
+}
+
+func (as async) launchRoutine(newJob job) {
+	as.Group.Go(func() error {
+		if newJob != noJob {
+			// First handle the provided job.
+			if err := as.takeAction(newJob); err != nil {
+				return err
+			}
+		}
+
+		// Now keep listening for new jobs
+		for j := range as.jobs {
+			if err := as.takeAction(j); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+	var maxRoutines = 128
+	if as.numRoutines >= maxRoutines {
+		return
+	}
+}
+
+func (as async) takeAction(j job) error {
+	if err := as.action(j.name, j.value); err != nil {
+		for _ = range as.jobs {
+			// Drain jobs as quickly as possible since there was an error
+		}
+		return err
+	}
+	return nil
+}
+
+func (as async) Wait() error {
+	close(as.jobs)
+	err := as.Group.Wait()
+	return err
+}
+
+func (as async) Add(name string, value interface{}) {
+	as.jobs <- job{name, value}
+}
+
+func (as async) AddError(err error) {
+	as.Go(func() error {
+		for _ = range as.jobs {
+			// Drain jobs as quickly as possible since there was an error
+		}
+		return err
+	})
+}
+
+type notAsync struct {
+	error
+	action
+}
+
+func newNotAsync(act action) *notAsync {
+	return &notAsync{action: act}
+}
+
+func (nas *notAsync) Wait() error {
+	return nas.error
+}
+
+func (nas *notAsync) Add(name string, value interface{}) {
+	// Act immediately unless there's a cached error.
+	if nas.error == nil {
+		nas.error = nas.action(name, value)
+	}
+}
+func (nas *notAsync) AddError(err error) {
+	if nas.error == nil {
+		nas.error = err
+	}
+}
+
+type newAsyncer func(action) asyncer
+
+func getNewAsyncer(useAsync bool) newAsyncer {
+	if useAsync {
+		return func(act action) asyncer { return newAsync(act) }
+	} else {
+		return func(act action) asyncer { return newNotAsync(act) }
+	}
+}

--- a/async.go
+++ b/async.go
@@ -65,16 +65,12 @@ func (as *async) launchRoutine(newJob job) {
 	go func() {
 		defer as.wg.Done()
 
-		// First handle the provided job.
-		if err := as.takeAction(newJob); err != nil {
-			return
-		}
-
-		// Now keep listening for new jobs
-		for j := range as.jobs {
-			if err := as.takeAction(j); err != nil {
+		pendingJobs := true
+		for pendingJobs {
+			if err := as.takeAction(newJob); err != nil {
 				return
 			}
+			newJob, pendingJobs = <-as.jobs
 		}
 	}()
 }

--- a/example/write-struct/main.go
+++ b/example/write-struct/main.go
@@ -67,7 +67,7 @@ func main() {
 
 	// Now read everything by wrapping it with a SplitReader
 	var readAll DemoTags
-	err = plc.NewSplitReader(device, false).ReadTag("DUMMY_STRUCT", &readAll)
+	err = plc.NewSplitReader(device).ReadTag("DUMMY_STRUCT", &readAll)
 	panicIfError(err, "Couldn't read entire struct")
 	demoVal.Level = originalLevel // Update to print the expectation
 	fmt.Printf("Read struct as %v (expecting %v)\n", readAll, demoVal)

--- a/example/write-struct/main.go
+++ b/example/write-struct/main.go
@@ -67,7 +67,7 @@ func main() {
 
 	// Now read everything by wrapping it with a SplitReader
 	var readAll DemoTags
-	err = plc.NewSplitReader(device).ReadTag("DUMMY_STRUCT", &readAll)
+	err = plc.NewSplitReader(device, false).ReadTag("DUMMY_STRUCT", &readAll)
 	panicIfError(err, "Couldn't read entire struct")
 	demoVal.Level = originalLevel // Update to print the expectation
 	fmt.Printf("Read struct as %v (expecting %v)\n", readAll, demoVal)

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.14
 require (
 	github.com/dijkstracula/go-ilock v0.0.0-20210108024717-0c2939783db9
 	github.com/stretchr/testify v1.6.1
+	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
 )

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/sync v0.0.0-20201207232520-09787c993a3a h1:DcqTD9SDLc+1P/r1EmRBwnVsrOwW+kk2vWf9n+1sGhs=
+golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=

--- a/pooled.go
+++ b/pooled.go
@@ -1,6 +1,6 @@
 package plc
 
-// A Pooled wraps another plc.ReadWriter with a work pool that runs a set number of concurrent operations.
+// Pooled wraps another plc.ReadWriter with a work pool that runs a set number of concurrent operations.
 type Pooled struct {
 	plc         ReadWriter
 	read, write tasker

--- a/splitter.go
+++ b/splitter.go
@@ -22,8 +22,13 @@ type SplitReader struct {
 var _ = Reader(SplitReader{}) // Compiler makes sure this type is a Reader
 
 // NewSplitReader returns a SplitReader.
-func NewSplitReader(rd Reader, useAsync bool) SplitReader {
-	return SplitReader{Reader: rd, newAsyncer: getNewAsyncer(useAsync)}
+func NewSplitReader(rd Reader) SplitReader {
+	return SplitReader{Reader: rd, newAsyncer: getNewAsyncer(true)}
+}
+
+// NewSplitReaderParallel returns a SplitReader which makes calls in parallel.
+func NewSplitReaderParallel(rd Reader) SplitReader {
+	return SplitReader{Reader: rd, newAsyncer: getNewAsyncer(false)}
 }
 
 func (rd SplitReader) ReadTag(name string, value interface{}) error {

--- a/splitter.go
+++ b/splitter.go
@@ -16,19 +16,27 @@ const TagPrefix = "plctag"
 // It also means nothing will be read if a nil or empty slice is provided; this code cannot infer the length.
 type SplitReader struct {
 	Reader
+	newAsyncer
 }
 
 var _ = Reader(SplitReader{}) // Compiler makes sure this type is a Reader
 
 // NewSplitReader returns a SplitReader.
-func NewSplitReader(rd Reader) SplitReader {
-	return SplitReader{rd}
+func NewSplitReader(rd Reader, useAsync bool) SplitReader {
+	return SplitReader{Reader: rd, newAsyncer: getNewAsyncer(useAsync)}
 }
 
-func (r SplitReader) ReadTag(name string, value interface{}) error {
+func (rd SplitReader) ReadTag(name string, value interface{}) error {
+	as := rd.newAsyncer(rd.Reader.ReadTag)
+	rd.readTagAsync(name, value, as)
+	return as.Wait()
+}
+
+func (rd SplitReader) readTagAsync(name string, value interface{}, as asyncer) {
 	v := reflect.ValueOf(value)
 	if v.Kind() != reflect.Ptr {
-		return newErrNonPointerRead(name, v.Kind())
+		as.AddError(newErrNonPointerRead(name, v.Kind()))
+		return
 	}
 
 	switch v.Elem().Kind() {
@@ -48,28 +56,23 @@ func (r SplitReader) ReadTag(name string, value interface{}) error {
 				fieldName = name + "." + fieldName // add prefix
 			}
 			field := str.Field(i)
-			if err := r.readValue(fieldName, field); err != nil {
-				return err
-			}
+			rd.readValue(fieldName, field, as)
 		}
 	case reflect.Array, reflect.Slice:
 		arr := v.Elem()
 		for idx := 0; idx < arr.Len(); idx++ {
-			if err := r.readValue(TagWithIndex(name, idx), arr.Index(idx)); err != nil {
-				break
-			}
+			rd.readValue(TagWithIndex(name, idx), arr.Index(idx), as)
 		}
 	default:
 		// Just try with the underlying type
-		return r.Reader.ReadTag(name, value)
+		as.Add(name, value)
 	}
-
-	return nil
 }
 
-func (r SplitReader) readValue(name string, val reflect.Value) error {
+func (rd SplitReader) readValue(name string, val reflect.Value, as asyncer) {
 	if !val.CanAddr() {
-		return fmt.Errorf("Cannot address %s", name)
+		as.AddError(fmt.Errorf("Cannot address %s", name))
+		return
 	}
 
 	valPointer := val.Addr().Interface()
@@ -83,7 +86,7 @@ func (r SplitReader) readValue(name string, val reflect.Value) error {
 		valPointer = val.Interface()
 	}
 
-	return r.ReadTag(name, valPointer)
+	rd.readTagAsync(name, valPointer, as)
 }
 
 // SplitWriter splits writes of structs and arrays into separate writes of their components.

--- a/splitter_test.go
+++ b/splitter_test.go
@@ -2,15 +2,76 @@ package plc
 
 import (
 	"reflect"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+func TestAsyncSplitReader(t *testing.T) {
+	const expected = uint8(7)
+	fakeRW := FakeReadWriter(map[string]interface{}{})
+	fakeRW[testTagName] = expected
+
+	// Now read the variable and make sure it is the same
+	var actual uint8
+	err := NewSplitReader(fakeRW, true).ReadTag(testTagName, &actual)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+}
+
+func TestAsyncSplitReaderMulti(t *testing.T) {
+	const expected = uint8(7)
+	fakeRW := FakeReadWriter(map[string]interface{}{})
+	sr := NewSplitReader(fakeRW, true)
+
+	for _, tc := range manyTypesToTest {
+		fakeRW[testTagName+reflect.TypeOf(tc).String()] = tc
+	}
+
+	for _, tc := range manyTypesToTest {
+		// Create an actual variable of the type we want to test
+		actual := reflect.New(reflect.TypeOf(tc)).Interface()
+		require.Equal(t, reflect.TypeOf(actual), reflect.PtrTo(reflect.TypeOf(tc)), "Created type must match desired type") // If this fails, it's a bug in test code, not the underlying code.
+
+		// Now read the variable and make sure it is the same
+		err := sr.ReadTag(testTagName+reflect.TypeOf(tc).String(), actual)
+		require.NoError(t, err)
+		require.Equal(t, tc, reflect.ValueOf(actual).Elem().Interface())
+	}
+}
+
+func TestAsyncSplitReaderMany(t *testing.T) {
+	fakeRW := FakeReadWriter(map[string]interface{}{})
+	sr := NewSplitReader(fakeRW, true)
+
+	const testLength = 512
+	expected := make([]int, testLength)
+	for i := 0; i < testLength; i++ {
+		fakeRW[testTagName+"["+strconv.Itoa(i)+"]"] = i
+		expected[i] = i
+	}
+
+	actual := make([]int, testLength)
+	err := sr.ReadTag(testTagName, &actual)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+}
+
+func TestAsyncSplitReaderError(t *testing.T) {
+	fakeRW := FakeReadWriter(map[string]interface{}{})
+	fakeRW[testTagName] = int(7)
+
+	// Read fails because the data type is different. Note int!=int32 or any other size.
+	var actual uint8
+	err := NewSplitReader(fakeRW, true).ReadTag(testTagName, &actual)
+	require.Error(t, err)
+}
+
 func newSplitReaderForTesting() (SplitReader, FakeReadWriter) {
 	fakeRW := FakeReadWriter(map[string]interface{}{})
-	return NewSplitReader(fakeRW), fakeRW
+	return NewSplitReader(fakeRW, false), fakeRW
 }
 
 func newSplitWriterForTesting() (SplitWriter, FakeReadWriter) {

--- a/splitter_test.go
+++ b/splitter_test.go
@@ -9,22 +9,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAsyncSplitReader(t *testing.T) {
+func TestSplitReaderParallel(t *testing.T) {
 	const expected = uint8(7)
 	fakeRW := FakeReadWriter(map[string]interface{}{})
 	fakeRW[testTagName] = expected
 
 	// Now read the variable and make sure it is the same
 	var actual uint8
-	err := NewSplitReader(fakeRW, true).ReadTag(testTagName, &actual)
+	err := NewSplitReaderParallel(fakeRW).ReadTag(testTagName, &actual)
 	require.NoError(t, err)
 	require.Equal(t, expected, actual)
 }
 
-func TestAsyncSplitReaderMulti(t *testing.T) {
+func TestSplitReaderParallelMulti(t *testing.T) {
 	const expected = uint8(7)
 	fakeRW := FakeReadWriter(map[string]interface{}{})
-	sr := NewSplitReader(fakeRW, true)
+	sr := NewSplitReaderParallel(fakeRW)
 
 	for _, tc := range manyTypesToTest {
 		fakeRW[testTagName+reflect.TypeOf(tc).String()] = tc
@@ -42,9 +42,9 @@ func TestAsyncSplitReaderMulti(t *testing.T) {
 	}
 }
 
-func TestAsyncSplitReaderMany(t *testing.T) {
+func TestSplitReaderParallelMany(t *testing.T) {
 	fakeRW := FakeReadWriter(map[string]interface{}{})
-	sr := NewSplitReader(fakeRW, true)
+	sr := NewSplitReaderParallel(fakeRW)
 
 	const testLength = 512
 	expected := make([]int, testLength)
@@ -59,19 +59,19 @@ func TestAsyncSplitReaderMany(t *testing.T) {
 	require.Equal(t, expected, actual)
 }
 
-func TestAsyncSplitReaderError(t *testing.T) {
+func TestSplitReaderParallelError(t *testing.T) {
 	fakeRW := FakeReadWriter(map[string]interface{}{})
 	fakeRW[testTagName] = int(7)
 
 	// Read fails because the data type is different. Note int!=int32 or any other size.
 	var actual uint8
-	err := NewSplitReader(fakeRW, true).ReadTag(testTagName, &actual)
+	err := NewSplitReaderParallel(fakeRW).ReadTag(testTagName, &actual)
 	require.Error(t, err)
 }
 
 func newSplitReaderForTesting() (SplitReader, FakeReadWriter) {
 	fakeRW := FakeReadWriter(map[string]interface{}{})
-	return NewSplitReader(fakeRW, false), fakeRW
+	return NewSplitReader(fakeRW), fakeRW
 }
 
 func newSplitWriterForTesting() (SplitWriter, FakeReadWriter) {


### PR DESCRIPTION
@matthias-stone, I made some significant changes to your proposal. 
* It doesn't spin up more goroutines than there are requests (and might create fewer). New routines are only created when old routines are blocked (to a max of 128).
* Rather than a `cancel` channel (which was tough to reason about regarding deadlocks), when an error is encountered, I try to drain the jobs channel.
* I created an `asyncer` interface and implemented both `async` and `notAsync` versions. That's hope `SplitReader` switches between those options.
* No need for `SplitWriter` to be async, so I didn't bother writing that code. (Maybe it would be good to add it to avoid breaking the `SplitWriter` constructor in the future?)