### PR TITLE
Fix bug in SplitReaderParallel

### DIFF
--- a/async.go
+++ b/async.go
@@ -150,13 +150,3 @@ func (nas *notAsync) AddError(err error) {
 		nas.error = err
 	}
 }
-
-type newAsyncer func(action) asyncer
-
-func getNewAsyncer(useAsync bool) newAsyncer {
-	if useAsync {
-		return func(act action) asyncer { return newAsync(act) }
-	} else {
-		return func(act action) asyncer { return newNotAsync(act) }
-	}
-}

--- a/async_test.go
+++ b/async_test.go
@@ -1,0 +1,43 @@
+package plc
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAsyncAddError(t *testing.T) {
+	as := newAsync(nil)
+	expected := errors.New("Test")
+	as.AddError(expected)
+	actual := as.Wait()
+	assert.Equal(t, expected, actual, "Error should be propagated")
+}
+
+func TestAsyncAddTwoErrors(t *testing.T) {
+	as := newAsync(nil)
+	expected1 := errors.New("Test1")
+	expected2 := errors.New("Test2")
+	as.AddError(expected1)
+	as.AddError(expected2)
+	actual := as.Wait()
+	if expected1 != actual && expected2 != actual {
+		assert.Fail(t, "Error message was not either expected value")
+	}
+}
+
+func TestNewAsync(t *testing.T) {
+	name := "TESTNAME"
+	value := int(8)
+	expErr := errors.New("Test")
+	as := newAsync(func(nm string, val interface{}) error {
+		require.Equal(t, name, nm, "Async should pass the name unchanged")
+		require.Equal(t, value, val, "Async should pass the value unchanged")
+		return expErr
+	})
+	as.Add(name, value)
+	err := as.Wait()
+	require.Equal(t, expErr, err, "Async should pass the error unchanged")
+}

--- a/async_test.go
+++ b/async_test.go
@@ -2,10 +2,11 @@ package plc
 
 import (
 	"errors"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestAsyncAddError(t *testing.T) {
@@ -33,11 +34,84 @@ func TestNewAsync(t *testing.T) {
 	value := int(8)
 	expErr := errors.New("Test")
 	as := newAsync(func(nm string, val interface{}) error {
-		require.Equal(t, name, nm, "Async should pass the name unchanged")
-		require.Equal(t, value, val, "Async should pass the value unchanged")
+		assert.Equal(t, name, nm, "Async should pass the name unchanged")
+		assert.Equal(t, value, val, "Async should pass the value unchanged")
 		return expErr
 	})
 	as.Add(name, value)
 	err := as.Wait()
-	require.Equal(t, expErr, err, "Async should pass the error unchanged")
+	assert.Equal(t, expErr, err, "Async should pass the error unchanged")
+}
+
+func TestAsyncMany(t *testing.T) {
+	sendVals := make([]int, 8)
+	receiveVals := make([]int, 8)
+	for i := range sendVals {
+		sendVals[i] = i
+		receiveVals[i] = -1
+	}
+
+	as := newAsync(func(nm string, val interface{}) error {
+		idx, err := strconv.Atoi(nm)
+		receiveVals[idx] = val.(int)
+		return err
+	})
+
+	for i := range sendVals {
+		as.Add(strconv.Itoa(i), sendVals[i])
+	}
+
+	err := as.Wait()
+	assert.NoError(t, err)
+	assert.Equal(t, sendVals, receiveVals)
+}
+
+func TestAsyncManyParallel(t *testing.T) {
+	numToTest := 8
+	sendVals := make([]int, numToTest)
+	receiveVals := make([]int, numToTest)
+	for i := range sendVals {
+		sendVals[i] = i
+		receiveVals[i] = -1
+	}
+
+	done := make(chan struct{})
+	count := make(chan int, numToTest)
+
+	as := newAsync(func(nm string, val interface{}) error {
+		idx, err := strconv.Atoi(nm)
+		count <- idx // indicate this index executed
+		receiveVals[idx] = val.(int)
+
+		<-done // Block until this channel is closed
+		return err
+	})
+
+	for i := range sendVals {
+		as.Add(strconv.Itoa(i), sendVals[i])
+	}
+
+	receivedIndices := uint32(0) // this limits the max number of parallel tests to 32
+	numReceived := 0
+
+outerLoop:
+	for {
+		select {
+		case <-time.After(50 * time.Millisecond):
+			assert.Fail(t, "Timeout in reading from parallel async")
+			break outerLoop
+		case idx := <-count:
+			receivedIndices |= 1 << uint32(idx)
+			numReceived++
+			if numReceived >= numToTest {
+				break outerLoop
+			}
+		}
+	}
+	close(done)
+
+	err := as.Wait()
+	assert.Equal(t, uint32(1<<numToTest)-1, receivedIndices, "Not all expected async occurred in parallel")
+	assert.NoError(t, err)
+	assert.Equal(t, sendVals, receiveVals)
 }

--- a/funcs.go
+++ b/funcs.go
@@ -1,0 +1,13 @@
+package plc
+
+type readerFunc func(string, interface{}) error
+
+func (rd readerFunc) ReadTag(name string, value interface{}) error {
+	return rd(name, value)
+}
+
+type writerFunc func(string, interface{}) error
+
+func (wr writerFunc) WriteTag(name string, value interface{}) error {
+	return wr(name, value)
+}

--- a/splitter.go
+++ b/splitter.go
@@ -16,19 +16,19 @@ const TagPrefix = "plctag"
 // It also means nothing will be read if a nil or empty slice is provided; this code cannot infer the length.
 type SplitReader struct {
 	Reader
-	newAsyncer
+	newAsyncer func(action) asyncer
 }
 
 var _ = Reader(SplitReader{}) // Compiler makes sure this type is a Reader
 
 // NewSplitReader returns a SplitReader.
 func NewSplitReader(rd Reader) SplitReader {
-	return SplitReader{Reader: rd, newAsyncer: getNewAsyncer(false)}
+	return SplitReader{Reader: rd, newAsyncer: func(act action) asyncer { return newNotAsync(act) }}
 }
 
 // NewSplitReaderParallel returns a SplitReader which makes calls in parallel.
 func NewSplitReaderParallel(rd Reader) SplitReader {
-	return SplitReader{Reader: rd, newAsyncer: getNewAsyncer(true)}
+	return SplitReader{Reader: rd, newAsyncer: func(act action) asyncer { return newAsync(act) }}
 }
 
 func (rd SplitReader) ReadTag(name string, value interface{}) error {

--- a/splitter.go
+++ b/splitter.go
@@ -23,12 +23,12 @@ var _ = Reader(SplitReader{}) // Compiler makes sure this type is a Reader
 
 // NewSplitReader returns a SplitReader.
 func NewSplitReader(rd Reader) SplitReader {
-	return SplitReader{Reader: rd, newAsyncer: getNewAsyncer(true)}
+	return SplitReader{Reader: rd, newAsyncer: getNewAsyncer(false)}
 }
 
 // NewSplitReaderParallel returns a SplitReader which makes calls in parallel.
 func NewSplitReaderParallel(rd Reader) SplitReader {
-	return SplitReader{Reader: rd, newAsyncer: getNewAsyncer(false)}
+	return SplitReader{Reader: rd, newAsyncer: getNewAsyncer(true)}
 }
 
 func (rd SplitReader) ReadTag(name string, value interface{}) error {


### PR DESCRIPTION
It turns out `true != false`. And a `bool` argument to a function is not the best idea.

This commit is mainly to fix a bug in `SplitReader`, but it also adds a lot of tests.