### PR TITLE
Allow library consumers to indicate if they are using the stub library

### DIFF
--- a/libplctag.go
+++ b/libplctag.go
@@ -27,3 +27,5 @@ func init() {
 			REQ_VER_MAJOR, REQ_VER_MINOR, REQ_VER_PATCH))
 	}
 }
+
+const StubActive = false

--- a/libplctag_stub.go
+++ b/libplctag_stub.go
@@ -7,3 +7,5 @@ package plc
 #include <libplctag.h>
 */
 import "C"
+
+const StubActive = true


### PR DESCRIPTION
* This can be useful for debugging